### PR TITLE
Add bare-bones support for non-p2p transaction details

### DIFF
--- a/end2end/TransactionDetails_test.js
+++ b/end2end/TransactionDetails_test.js
@@ -1,6 +1,6 @@
 Feature('transaction-details-page')
 
-function seeRowHeaders (I) {
+function seeUserTxnRowHeaders (I) {
   I.see('Version ID')
   I.see('Status')
   I.see('Transaction Type')
@@ -20,7 +20,7 @@ function seeRowHeaders (I) {
   I.see('Script Hash')
 }
 
-function seeRowData (I) {
+function seeUserTxnRowData (I) {
   I.see('64117651')
   I.see('executed')
   I.see('user')
@@ -38,12 +38,25 @@ function seeRowData (I) {
   I.see('04ea43107fafc12adcd09f6c68d63e194675d0ce843a7faf7cceb6c813db9d9a')
 }
 
-Scenario('test after data has loaded', ({ I }) => {
+function seeUnsupportedTransactionCard(I) {
+  I.see('Unsupported Transaction')
+}
+
+Scenario('user transaction', ({ I }) => {
   I.amOnPage('/txn/64117651')
   I.seeMainWrapper()
 
   I.waitForElement('table', 10)
   I.see('Transaction Details')
-  seeRowHeaders(I)
-  seeRowData(I)
+  seeUserTxnRowHeaders(I)
+  seeUserTxnRowData(I)
+})
+
+Scenario('metadata transaction', ({ I }) => {
+  I.amOnPage('/txn/321960031')
+  I.seeMainWrapper()
+
+  I.waitForElement('.accordion', 10)
+  I.see('Transaction Details')
+  seeUnsupportedTransactionCard(I)
 })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^17.0.0",
     "react-bootstrap": "^2.0.0-rc.1",
     "react-dom": "^17.0.0",
+    "react-json-pretty": "^2.2.0",
     "react-router-dom": "^5.3.0",
     "react-table": "^7.7.0",
     "react-tooltip": "^4.2.21",

--- a/src/BlockchainClient.test.tsx
+++ b/src/BlockchainClient.test.tsx
@@ -1,7 +1,7 @@
 import {
   setBlockchainApiResponse, setBlockchainNetworkError,
   setupIntegrationTestApiServer
-} from '../../../test_utils/IntegrationTestApiServerTools'
+} from '../test_utils/IntegrationTestApiServerTools'
 import { getBlockchainTransaction } from './BlockchainClient'
 
 const server = setupIntegrationTestApiServer()

--- a/src/BlockchainClient.tsx
+++ b/src/BlockchainClient.tsx
@@ -1,8 +1,8 @@
 import fetch from 'isomorphic-fetch'
-import Config from '../../config.json'
+import Config from './config.json'
 import { JsonRpcResponse } from '@libra-opensource/client-sdk-typescript/dist/jsonRpc/types'
-import { BlockchainTransaction } from '../../api_models/BlockchainTransaction'
-import { DataOrErrors, FetchResponse } from '../../FetchType'
+import { BlockchainTransaction } from './api_models/BlockchainTransaction'
+import { DataOrErrors, FetchResponse } from './FetchType'
 
 function transformHttpErrorsIntoFailedPromise<T> (response: FetchResponse<T>) {
   if (!response.ok) {

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
@@ -1,0 +1,142 @@
+import '@testing-library/jest-dom' // provides `expect(...).toBeInTheDocument()`
+import TxnDetailsPage from './TxnDetailsPage'
+import { render, screen, waitForElementToBeRemoved, within } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { getBlockchainTransaction } from '../../BlockchainClient'
+import { BlockchainTransaction } from '../../api_models/BlockchainTransaction'
+
+jest.mock('../../BlockchainClient', () => ({
+  ...jest.requireActual('../../BlockchainClient'),
+  getBlockchainTransaction: jest.fn(),
+}))
+const mockUserTransaction = {
+  bytes: '007f7c1917f1191487e3ab429b0dc3b118830f00000000000001e001a11ceb0b010000000701000202020403061004160205181d0735600895011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000b4469656d4163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000103585553035855530004034197763c1cc5f25397520530c76e0a860101000000000000000400040040420f0000000000000000000000000003585553d3e7576000000000150020f1910421e2a1433027a7b0e444bed67469b573adba72353ad3cde20b54e1b7a040e7b6730712283f887f52f9dd7bfb9210801c3b1093fe13ca9a5d00f129543cc0eda55d66b2d8214e5acc848626685c6098f9c09a127ee15bbf545ae69495450f',
+  events: [],
+  gas_used: 511,
+  hash: 'f77681996cc577851ed50b588b4de6e7290b615e05625040d24a3ceec7f9c624',
+  transaction: {
+    chain_id: 21,
+    expiration_timestamp_secs: 1616373715,
+    gas_currency: 'XUS',
+    gas_unit_price: 0,
+    max_gas_amount: 1000000,
+    public_key: 'f1910421e2a1433027a7b0e444bed67469b573adba72353ad3cde20b54e1b7a0',
+    script: {
+      amount: 1,
+      arguments: [
+        '{ADDRESS: 4197763C1CC5F25397520530C76E0A86}',
+        '{U64: 1}',
+        '{U8Vector: 0x}',
+        '{U8Vector: 0x}'
+      ],
+      code: 'a11ceb0b010000000701000202020403061004160205181d0735600895011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000b4469656d4163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b05110202',
+      currency: 'XUS',
+      metadata: 'sooo meta',
+      metadata_signature: 'Hitchcock goes here',
+      receiver: '4197763c1cc5f25397520530c76e0a86',
+      type: 'peer_to_peer_with_metadata',
+      type_arguments: [
+        'XUS'
+      ]
+    },
+    script_bytes: 'e001a11ceb0b010000000701000202020403061004160205181d0735600895011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000b4469656d4163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b0511020201070000000000000000000000000000000103585553035855530004034197763c1cc5f25397520530c76e0a8601010000000000000004000400',
+    script_hash: '04ea43107fafc12adcd09f6c68d63e194675d0ce843a7faf7cceb6c813db9d9a',
+    secondary_public_keys: [],
+    secondary_signature_schemes: [],
+    secondary_signatures: [],
+    secondary_signers: [],
+    sender: '7f7c1917f1191487e3ab429b0dc3b118',
+    sequence_number: 3971,
+    signature: 'e7b6730712283f887f52f9dd7bfb9210801c3b1093fe13ca9a5d00f129543cc0eda55d66b2d8214e5acc848626685c6098f9c09a127ee15bbf545ae69495450f',
+    signature_scheme: 'Scheme::Ed25519',
+    type: 'user'
+  },
+  version: 66651271,
+  vm_status: {
+    type: 'executed'
+  }
+}
+
+const mockMetadataTransaction = {
+  bytes: '0220acc2e890f996e8d710a56aeddf01e5797f2366616a9d0d349ebc8d784c5c2880e742000000000000d12bbd0af5ce050010003aaee9f2794e4d2863f58e5ba0434f1b8a315ecb5da3bf65324e5c98d7c5d21ee66634a9d307e598a9001c70350f573b4f0b8a914678fd087935cf01b7cc783ec43d8df8e6a8d192cb7db7d88ceaaa49e14093c12d40d8fe9ac2af30bc6fc463e721fbc1999c3c721caedfea9ab00d76e8f447ac03d161366b1c95e3230aa98dba6983cdfdd9577a0220264a4c52ab92d4d3baf2716b09d4f863176dc7798094511281e2e59b01c36da19fd56e067aab257bf8e91862d2d41d0629d9618800b68cf702c43aff3d9ada6a88041bd13fc0a38f4b8de6ef37e84402873b33feedc8dacb8b498a61bddfb9cccc2ddc8ba5ed5d9b97d7f1ca058bcfc035a072e887ed5d9b97d7f1ca058bcfc035a072e887',
+  events: [],
+  gas_used: 100000000,
+  hash: 'c5c969761211f65d41a8a747f66e45309a45e71c03ba915412baabfaea247cea',
+  transaction: {
+    timestamp_usecs: 1634926726032337,
+    type: 'blockmetadata'
+  },
+  version: 321960031,
+  vm_status: {
+    type: 'executed'
+  }
+}
+
+const renderWithTransaction = async (txn: BlockchainTransaction = mockUserTransaction) => {
+  // @ts-ignore TS is bad at mocking
+  getBlockchainTransaction.mockResolvedValue({
+    errors: null,
+    data: txn
+  })
+  const mockHistory = {
+    history: {} as any,
+    location: {} as any,
+    match: {
+      path: '/txn/:version',
+      url: '/txn/66651271',
+      isExact: true,
+      params: {
+        version: '66651271'
+      }
+    }
+  }
+  render(<BrowserRouter><TxnDetailsPage {...mockHistory}/></BrowserRouter>)
+  await waitForElementToBeRemoved(screen.queryByRole('loading'))
+}
+
+it('should display data in a table for user transactions', async function () {
+  await renderWithTransaction()
+
+  expect(document.getElementById('objectPropertiesTable')).not.toEqual(null)
+  const detailsTable = document.getElementById('objectPropertiesTable')!
+  expect(within(detailsTable).queryByText('Version ID')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Status')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Transaction Type')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('From')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('To')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Amount')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Expiration')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Currency')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Metadata')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Metadata Signature')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Sequence Number')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Gas Used')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Gas Unit Price')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Max Gas Amount')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Public Key')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Signature')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Script Hash')).toBeInTheDocument()
+
+  expect(within(detailsTable).queryByText('66651271')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('executed')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('user')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('7f7c1917f1191487e3ab429b0dc3b118')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('4197763c1cc5f25397520530c76e0a86')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('1')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('1616373715')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('XUS')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('XUS')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('sooo meta')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('Hitchcock goes here')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('511')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('0')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('1000000')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('f1910421e2a1433027a7b0e444bed67469b573adba72353ad3cde20b54e1b7a0')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('e7b6730712283f887f52f9dd7bfb9210801c3b1093fe13ca9a5d00f129543cc0eda55d66b2d8214e5acc848626685c6098f9c09a127ee15bbf545ae69495450f')).toBeInTheDocument()
+  expect(within(detailsTable).queryByText('04ea43107fafc12adcd09f6c68d63e194675d0ce843a7faf7cceb6c813db9d9a')).toBeInTheDocument()
+})
+
+it('should display a helpful message for metadata transactions', async function () {
+  await renderWithTransaction(mockMetadataTransaction)
+  expect(screen.queryByText('Unsupported Transaction')).toBeInTheDocument()
+})

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
@@ -9,6 +9,8 @@ import {
 import { RouteComponentProps } from 'react-router-dom'
 import MainWrapper from '../../MainWrapper'
 import BTable from 'react-bootstrap/Table'
+import { Accordion, Alert, Card } from 'react-bootstrap'
+import JSONPretty from 'react-json-pretty'
 
 function ObjectPropertiesTable ({ object }: { object: Object }) {
   return (
@@ -17,6 +19,7 @@ function ObjectPropertiesTable ({ object }: { object: Object }) {
           bordered
           hover
           className="border"
+          id="objectPropertiesTable"
       >
     <tbody>
       {Object.keys(object).map(function (property) {
@@ -33,7 +36,17 @@ function ObjectPropertiesTable ({ object }: { object: Object }) {
   )
 }
 
-function TxnDetailsPageWithResponse ({ data }: { data: BlockchainTransaction | undefined}) {
+function UnsupportedTxnDetailsTable ({ data }: { data: BlockchainTransaction | undefined}) {
+  return (
+    <Alert variant={'warning'} style={{ width: '30rem' }}>
+      <h4>Unsupported Transaction</h4>
+      <p>Diem Explorer is still being built and does not support this type of transaction yet.</p>
+      <p>In the mean time the raw data is displayed here for your convenience</p>
+    </Alert>
+  )
+}
+
+function UserTxnDetailsTable ({ data }: { data: BlockchainTransaction | undefined}) {
   const userTxnData = (data?.transaction as BlockchainUserTxnData)
   const txnScript = (userTxnData.script as PeerToPeerWithMetadataBlockChainScript)
   const txnForDisplay = {
@@ -55,14 +68,47 @@ function TxnDetailsPageWithResponse ({ data }: { data: BlockchainTransaction | u
     Signature: userTxnData.signature,
     'Script Hash': userTxnData.script_hash
   }
+  return (<ObjectPropertiesTable object={txnForDisplay} />)
+}
+
+function transactionIsSupported(data: BlockchainTransaction | undefined) {
+  return (!!data && !!data.transaction && data.transaction.type === 'user')
+}
+
+function TxnDetailsTable ({ data }: { data: BlockchainTransaction | undefined}) {
+  return (
+    <>
+      <h2 className="mb-5" role="note">
+        Transaction Details
+      </h2>
+      { transactionIsSupported(data)
+        ? <UserTxnDetailsTable data={data} />
+        : <UnsupportedTxnDetailsTable data={data} />
+      }
+    </>
+  )
+}
+
+function RawTxn ({ data }: { data: BlockchainTransaction | undefined}) {
+  return (
+    <Accordion activeKey={transactionIsSupported(data) ? undefined : '0'}>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>Raw Transaction</Accordion.Header>
+        <Accordion.Body>
+          <JSONPretty data={data}></JSONPretty>
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  )
+}
+
+function TxnDetailsPageWithResponse ({ data }: { data: BlockchainTransaction | undefined}) {
   return (
       <MainWrapper>
-          <>
-              <h2 className="mb-5" role="note">
-                  Transaction Details
-              </h2>
-              <ObjectPropertiesTable object={txnForDisplay} />
-          </>
+        <>
+          <TxnDetailsTable data={data} />
+          <RawTxn data={data} />
+        </>
       </MainWrapper>
   )
 }
@@ -76,7 +122,7 @@ interface TxnDetailsPageProps extends RouteComponentProps<TxnDetailsPageMatch> {
 export default function TxnDetailsPage (props: TxnDetailsPageProps) {
   return (
         <ApiRequestPage request={getTransaction} args={[props.match.params.version]}>
-            <TxnDetailsPageWithResponse data={undefined} />
+          <TxnDetailsPageWithResponse data={undefined} />
         </ApiRequestPage>
   )
 }

--- a/src/TransactionClient.ts
+++ b/src/TransactionClient.ts
@@ -1,6 +1,6 @@
 import { AnalyticsTransaction } from './api_models/AnalyticsTransaction'
 import { LandingPageTransaction } from './Pages/LandingPage/LandingPageTransactionModel'
-import { getBlockchainTransaction } from './Pages/TxnDetailsPage/BlockchainClient'
+import { getBlockchainTransaction } from './BlockchainClient'
 import { BlockchainTransaction } from './api_models/BlockchainTransaction'
 import { DataOrErrors } from './FetchType'
 import { postQueryToAnalyticsApi } from './AnalyticsClient'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7032,6 +7032,13 @@ react-is@^17.0.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-json-pretty@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-json-pretty/-/react-json-pretty-2.2.0.tgz#9ba907d2b08d87e90456d87b6025feeceb8f63cf"
+  integrity sha512-3UMzlAXkJ4R8S4vmkRKtvJHTewG4/rn1Q18n0zqdu/ipZbUPLVZD+QwC7uVcD/IAY3s8iNVHlgR2dMzIUS0n1A==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"


### PR DESCRIPTION
Fixes #9 by displaying a friendly "unsupported" message and pretty-printing the raw transaction.

![image](https://user-images.githubusercontent.com/1739196/139156645-7ea9c1ae-a876-4635-901c-0d8b135e5500.png)
