### PR TITLE
[tf][helm] psp and choice of ingress

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "explorer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "explorer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "explorer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "explorer.labels" -}}
+helm.sh/chart: {{ include "explorer.chart" . }}
+{{ include "explorer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "explorer.selectorLabels" -}}
+app.kubernetes.io/part-of: {{ include "explorer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "explorer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "explorer.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/explorer.yaml
+++ b/helm/templates/explorer.yaml
@@ -1,51 +1,68 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: explorer
+  name: {{ include "explorer.fullname" . }}
   labels:
-    app: explorer
+    {{- include "explorer.labels" . | nindent 4 }}
+    app.kubernetes.io/name: explorer
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: explorer
+      {{- include "explorer.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: explorer
   template:
     metadata:
       labels:
-        app: explorer
+        {{- include "explorer.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: explorer
     spec:
-      serviceAccountName: default
+      serviceAccountName: {{ include "explorer.serviceAccountName" . }}
       {{- with .Values }}
       containers:
-        - name: main
-          image: "{{ required "A valid repo entry required!" .repo }}:{{ required "A valid tag entry required!" .tag }}"
-          imagePullPolicy: Always
-          env:
-          {{- with .env }}
-          - name: DIEMX_CHAIN
-            value: {{ required "chain required" .chain }}
-          - name: DIEMX_ENV
-            value: {{ required "env required" .env }}
-          - name: DIEMX_BASE_URL
-            value: {{ required "base_url required" .base_url }}
-          - name: DIEMX_GRAPHQL_URL
-            value: {{ required "graphql_url required" .graphql_url }}
-          - name: DIEMX_BLOCKCHAIN_URL
-            value: {{ required "blockchain_jsonrpc_url required" .blockchain_jsonrpc_url }}
-          - name: DIEMX_BLOCKCHAIN_API_URL
-            value: {{ required "blockchain_restapi_url required" .blockchain_restapi_url }}
-          {{- end }}
+      - name: main
+        image: "{{ required "A valid repo entry required!" .repo }}:{{ required "A valid tag entry required!" .tag }}"
+        imagePullPolicy: Always
+        env:
+        {{- with .env }}
+        - name: DIEMX_CHAIN
+          value: {{ required "chain required" .chain }}
+        - name: DIEMX_ENV
+          value: {{ required "env required" .env }}
+        - name: DIEMX_BASE_URL
+          value: {{ required "base_url required" .base_url }}
+        - name: DIEMX_GRAPHQL_URL
+          value: {{ required "graphql_url required" .graphql_url }}
+        - name: DIEMX_BLOCKCHAIN_URL
+          value: {{ required "blockchain_jsonrpc_url required" .blockchain_jsonrpc_url }}
+        - name: DIEMX_BLOCKCHAIN_API_URL
+          value: {{ required "blockchain_restapi_url required" .blockchain_restapi_url }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: 80
       {{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: explorer
+  name: {{ include "explorer.fullname" . }}
   labels:
-    app: explorer
+    {{- include "explorer.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  selector:
+    {{- include "explorer.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: explorer
   ports:
   - port: 80
-  selector:
-    app: explorer
+    targetPort: 80
+  type: {{ .Values.service.type }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,12 +1,26 @@
-apiVersion: networking.k8s.io/v1
+{{- if .Values.ingress.create -}}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: explorer
+  name: {{ include "explorer.fullname" . }}
+  labels:
+    {{- include "explorer.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $value := .Values.ingressAnnotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value }}
     {{- end }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
 spec:
+  rules:
+  {{- if eq .Values.ingress.type "alb" }}
+    - host: {{ .Values.hostname }}
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: {{ include "explorer.fullname" . }}
+              servicePort: 80
+  {{- else if eq .Values.ingress.type "nginx" }}
   tls:
     - hosts:
         - {{ .Values.hostname }}
@@ -22,3 +36,5 @@ spec:
                 name: explorer
                 port:
                   number: 80
+  {{- end }}
+{{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "explorer.serviceAccountName" . }}
+  labels:
+{{ include "explorer.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,6 @@
 repo:
 tag:
 hostname:
-ingressAnnotations:
 env:
   chain:
   env:
@@ -9,3 +8,18 @@ env:
   graphql_url:
   blockchain_jsonrpc_url:
   blockchain_restapi_url:
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+
+service:
+  # Change this to LoadBalancer to expose the explorer endpoint externally
+  type: ClusterIP
+  externalTrafficPolicy:
+  loadBalancerSourceRanges: []
+  annotations: {}

--- a/terraform/modules/explorer/main.tf
+++ b/terraform/modules/explorer/main.tf
@@ -11,7 +11,6 @@ resource "helm_release" "explorer" {
       repo               = var.image_repo
       tag                = var.image_tag
       hostname           = var.hostname
-      ingressAnnotations = var.ingress_annotations
       env = {
         chain                  = var.chain
         env                    = var.env
@@ -19,6 +18,22 @@ resource "helm_release" "explorer" {
         graphql_url            = var.graphql_url
         blockchain_jsonrpc_url = var.blockchain_jsonrpc_url
         blockchain_restapi_url = var.blockchain_restapi_url
+      }
+      serviceAccount = {
+        create = var.create_service_account
+        name = var.service_account_name
+        annotations = var.service_account_annotations
+      }
+      ingress = {
+        create = var.create_ingress
+        annotations = var.ingress_annotations
+        type = var.ingress_type
+      }
+      service = {
+        type = var.service_type
+        externalTrafficPolicy = var.external_traffic_policy
+        loadBalancerSourceRanges = var.load_balancer_source_ranges
+        annotations = var.service_annotations
       }
     }),
   ]

--- a/terraform/modules/explorer/variables.tf
+++ b/terraform/modules/explorer/variables.tf
@@ -7,15 +7,7 @@ variable "image_tag" {
 variable "hostname" {
   description = "The hostname where this would be deployed"
 }
-variable "ingress_annotations" {
-  description = "The list of annotations to be applied on the ingress resource"
-  default = {
-    # By default using nginx ingress class and cert-manager for certificate management
-    "kubernetes.io/ingress.class"               = "nginx"
-    "cert-manager.io/cluster-issuer"            = "letsencrypt-prod"
-    "acme.cert-manager.io/http01-ingress-class" = "nginx"
-  }
-}
+
 variable "chain" {
   description = "The blockchain type (eg: DPN, experimental)"
 }
@@ -33,4 +25,46 @@ variable "blockchain_jsonrpc_url" {
 }
 variable "blockchain_restapi_url" {
   description = "The rest api endpoint used"
+}
+
+# service account
+variable "create_service_account" {
+  description = "Whether to create service account"
+}
+variable "service_account_name" {
+  description = "Name of service account; creates if create_service_account set"
+}
+variable "service_account_annotations" {
+  description = "Service account annotations as a map"
+}
+
+# # ingress
+variable "create_ingress" {
+  description = "Whether to create a kubernetes ingress"
+}
+variable "ingress_annotations" {
+  description = "The list of annotations to be applied on the ingress resource"
+  default = {
+    # By default using nginx ingress class and cert-manager for certificate management
+    "kubernetes.io/ingress.class"               = "nginx"
+    "cert-manager.io/cluster-issuer"            = "letsencrypt-prod"
+    "acme.cert-manager.io/http01-ingress-class" = "nginx"
+  }
+}
+variable "ingress_type" {
+  description = "Supports ALB and NGINX"
+}
+
+# service
+variable "service_type" {
+  default = "ClusterIP"
+}
+variable "external_traffic_policy" {
+  default = ""
+}
+variable "load_balancer_source_ranges" {
+  default = []
+}
+variable "service_annotations" {
+  default = {}
 }


### PR DESCRIPTION
### General
* helper file to generate standard labels
* option to specify or create service account for PSP purposes
* fix some yaml indentation styling

### Ingress
Added an option to specify service and ingress type. Across our reference deployments we're using ALB and nginx ingress controller, each of which require specific service types (e.g. NodePort for ALB). Since each ingress has a slightly different spec, and because we want to ship the ingress with this helm chart, we need to specify each option.

### Test plan

Apply to personal cluster using TF module. See related PR in partners