### PR TITLE
Provide links from Txn details page to address page

### DIFF
--- a/end2end/TransactionDetails_test.js
+++ b/end2end/TransactionDetails_test.js
@@ -42,6 +42,14 @@ function seeUnsupportedTransactionCard(I) {
   I.see('Unsupported Transaction')
 }
 
+function navigateToAddressPage(I) {
+  I.click('e4d382572c1286984aecfae682db0370')
+  I.seeInCurrentUrl('/address/e4d382572c1286984aecfae682db0370')
+  I.goBack()
+  I.click('ed53d2c05bc4ff33d15a744f35010026')
+  I.seeInCurrentUrl('/address/ed53d2c05bc4ff33d15a744f35010026')
+}
+
 Scenario('user transaction', ({ I }) => {
   I.amOnPage('/txn/64117651')
   I.seeMainWrapper()
@@ -50,6 +58,8 @@ Scenario('user transaction', ({ I }) => {
   I.see('Transaction Details')
   seeUserTxnRowHeaders(I)
   seeUserTxnRowData(I)
+
+  navigateToAddressPage(I)
 })
 
 Scenario('metadata transaction', ({ I }) => {

--- a/src/ObjectPropertiesTable.tsx
+++ b/src/ObjectPropertiesTable.tsx
@@ -1,7 +1,12 @@
 import BTable from 'react-bootstrap/Table'
-import React from 'react'
+import React, { ReactChild } from 'react'
 
-export default function ObjectPropertiesTable({ object }: { object: Object }) {
+interface ObjectPropertiesTableProps {
+  object: {
+    [key: string]: string | number | undefined | ReactChild
+  }
+}
+export default function ObjectPropertiesTable({ object }: ObjectPropertiesTableProps) {
   return (
     <BTable
       responsive

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -7,12 +7,13 @@ import Table from '../../Table'
 import { useHistory } from 'react-router-dom'
 import './LandingPage.css'
 import { TransactionVersion } from '../../TableComponents/Link'
-import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
+
 import {
   AnalyticsTransaction,
   transformAnalyticsTransactionIntoTransaction,
 } from '../../api_models/AnalyticsTransaction'
 import { DataOrErrors } from '../../api_clients/FetchTypes'
+import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
 
 function Wrapper(props: { children: ReactNode }) {
   return (

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
@@ -11,6 +11,7 @@ import { Accordion, Alert } from 'react-bootstrap'
 import JSONPretty from 'react-json-pretty'
 import { getBlockchainTransaction } from '../../api_clients/BlockchainJsonRpcClient'
 import ObjectPropertiesTable from '../../ObjectPropertiesTable'
+import { AccountAddress } from '../../TableComponents/Link'
 
 function UnsupportedTxnDetailsTable() {
   return (
@@ -38,8 +39,8 @@ function UserTxnDetailsTable({
     'Version ID': data?.version,
     Status: data?.vm_status?.type,
     'Transaction Type': data?.transaction?.type,
-    From: userTxnData.sender,
-    To: txnScript.receiver,
+    To: AccountAddress({ value: txnScript.receiver }),
+    From: AccountAddress({ value: userTxnData.sender }),
     Amount: txnScript.amount,
     Expiration: userTxnData.expiration_timestamp_secs,
     Currency: userTxnData.gas_currency,

--- a/src/TableComponents/Link.tsx
+++ b/src/TableComponents/Link.tsx
@@ -24,3 +24,6 @@ Link.displayName = 'DiemExplorerLink'
 export function TransactionVersion(props: { value: string }) {
   return Link({ className: 'transaction-link', linkPrefix: '/txn/' })(props)
 }
+export function AccountAddress(props: { value: string }) {
+  return Link({ className: 'address-link', linkPrefix: '/address/' })(props)
+}

--- a/steps_file.js
+++ b/steps_file.js
@@ -22,5 +22,9 @@ module.exports = function () {
       this.see(pageName, 'a')
       this.click(pageName)
     },
+
+    goBack() {
+      this.executeScript('window.history.back();')
+    },
   })
 }


### PR DESCRIPTION
Implements #23  -- Reach Account Page From Transaction Details Page:
* Explorer clicks on From value and navigates to Transaction Details page
* Explorer clicks on To Value and navigates to Transaction Details page
* 
Test plan: 
e2e tests in `end2end/TransactionDetailsPage_test.js`