### PR TITLE
Display top 10 XUS transfers in the last 24 hours on leaderboard page

### DIFF
--- a/end2end/Leaderboard_test.js
+++ b/end2end/Leaderboard_test.js
@@ -7,7 +7,11 @@ function seeRowHeaders(I) {
 }
 
 function seeRowData(I) {
-  // TODO: use mock data
+  within('[data-testid="top-10-transactions"] tr:first-child', () => {
+    I.see('1')
+    I.see('2345')
+    I.see('5432')
+  })
 }
 
 Scenario('navigating to the leaderboard page', ({ I }) => {

--- a/end2end/Leaderboard_test.js
+++ b/end2end/Leaderboard_test.js
@@ -7,11 +7,9 @@ function seeRowHeaders(I) {
 }
 
 function seeRowData(I) {
-  within('[data-testid="top-10-transactions"] tr:first-child', () => {
-    I.see('1')
-    I.see('2345')
-    I.see('5432')
-  })
+  I.see('1')
+  I.see('2345')
+  I.see('5432')
 }
 
 Scenario('navigating to the leaderboard page', ({ I }) => {

--- a/end2end/Leaderboard_test.js
+++ b/end2end/Leaderboard_test.js
@@ -1,0 +1,26 @@
+Feature('leaderboard-page')
+
+function seeRowHeaders(I) {
+  I.see('Ranking')
+  I.see('Version')
+  I.see('Amount (XUS)')
+}
+
+function seeRowData(I) {
+  // TODO: use mock data
+}
+
+Scenario('navigating to the leaderboard page', ({ I }) => {
+  I.amOnPage('/')
+  I.click('Leaderboard')
+  I.seeInCurrentUrl('/leaderboard')
+  I.see('Diem Leaderboard')
+})
+
+Scenario('displaying the top 10 transactions in the past 24 hours', ({ I }) => {
+  I.amOnPage('/leaderboard')
+  I.see('Top 10 Transactions (XUS)')
+
+  seeRowHeaders(I)
+  seeRowData(I)
+})

--- a/end2end/wiremock/mappings/analyticsApi/postForPaymentEvents.json
+++ b/end2end/wiremock/mappings/analyticsApi/postForPaymentEvents.json
@@ -1,4 +1,5 @@
 {
+  "priority": 2,
   "request": {
     "method": "POST",
     "url": "/v1/graphql",

--- a/end2end/wiremock/mappings/analyticsApi/postForTop10PaymentEvents.json
+++ b/end2end/wiremock/mappings/analyticsApi/postForTop10PaymentEvents.json
@@ -1,0 +1,35 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "url": "/v1/graphql",
+    "bodyPatterns" : [ {
+      "matchesJsonPath" : {
+        "expression": "$.query",
+        "contains": "query{sentpayment_events(limit:10,where:{commit_timestamp:"
+      }
+    } ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Methods" : "*",
+      "Access-Control-Allow-Headers": "*"
+    },
+    "jsonBody": {
+      "data": {
+        "sentpayment_events": [
+          {
+            "transaction_version": 2345,
+            "amount": 5432
+          },
+          {
+            "transaction_version": 987,
+            "amount": 789
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/ApiRequestComponent.test.tsx
+++ b/src/ApiRequestComponent.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom' // provides `expect(...).toBeInTheDocument()`
 import { act, render, screen, waitFor } from '@testing-library/react'
-import ApiRequestPage from './ApiRequestPage'
+import ApiRequestComponent from './ApiRequestComponent'
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 
@@ -36,7 +36,7 @@ const mockArgs = [{ arg: 'value' }]
 function renderSubject(args: any[] | undefined) {
   render(
     <BrowserRouter>
-      <ApiRequestPage
+      <ApiRequestComponent
         request={mockRequest}
         args={args}
         loadingComponent={
@@ -45,7 +45,7 @@ function renderSubject(args: any[] | undefined) {
         errorComponent={<ErrorComponent errors={[]} />}
       >
         <ChildComponent data={undefined} />
-      </ApiRequestPage>
+      </ApiRequestComponent>
     </BrowserRouter>
   )
 }
@@ -60,7 +60,7 @@ beforeEach(() => {
   mockRequest.mockImplementation(() => apiPromise)
 })
 
-describe('ApiRequestPage', () => {
+describe('ApiRequestComponent', () => {
   describe('Passing Arguments', function () {
     it('should pass each argument separately', function () {
       const myArgs = [1, 'bananas', { deeply: { nested: { object: true } } }]

--- a/src/ApiRequestComponent.tsx
+++ b/src/ApiRequestComponent.tsx
@@ -45,7 +45,7 @@ function ApiRequestComponent<T>({
   useEffect(() => {
     async function getResponse() {
       await request(...args).then((apiResponse) => {
-        if (apiResponse.data) {
+        if ('data' in apiResponse) {
           setResponse(apiResponse.data)
           setLoading(false)
         } else {

--- a/src/ApiRequestComponent.tsx
+++ b/src/ApiRequestComponent.tsx
@@ -11,25 +11,41 @@ interface ApiRequestPageProps<T> {
   errorComponent?: ReactElement
 }
 
-function DefaultErrorComponent() {
+export function PlainErrorComponent() {
+  return (
+    <span role='dialog' className='network-error'>
+      Something went wrong. Please try again later
+    </span>
+  )
+}
+
+export function FullPageErrorComponent() {
   return (
     <MainWrapper>
-      <span role="dialog" className="network-error">
-        Something went wrong. Please try again later
-      </span>
+      <PlainErrorComponent />
     </MainWrapper>
   )
 }
 
-function DefaultLoadingComponent() {
+const DefaultErrorComponent = FullPageErrorComponent
+
+export function PlainLoadingComponent() {
+  return (
+    <span className='loading' role='loading'>
+      Loading, please wait
+    </span>
+  )
+}
+
+export function FullPageLoadingComponent() {
   return (
     <MainWrapper>
-      <span className="loading" role="loading">
-        Loading, please wait
-      </span>
+      <PlainLoadingComponent />
     </MainWrapper>
   )
 }
+
+const DefaultLoadingComponent = FullPageLoadingComponent
 
 function ApiRequestComponent<T>({
   request,

--- a/src/ApiRequestComponent.tsx
+++ b/src/ApiRequestComponent.tsx
@@ -31,7 +31,7 @@ function DefaultLoadingComponent() {
   )
 }
 
-function ApiRequestPage<T>({
+function ApiRequestComponent<T>({
   request,
   args = [],
   children,
@@ -62,7 +62,7 @@ function ApiRequestPage<T>({
     if (loading) {
       return <>{React.cloneElement(loadingComponent)}</>
     } else if (errors && errors.length) {
-      console.error('Error loading the ApiRequestPage: ', errors)
+      console.error('Error loading the ApiRequestComponent: ', errors)
       return <>{React.cloneElement(errorComponent, { errors })}</>
     } else {
       return <>{React.cloneElement(children, { data: response })}</>
@@ -72,4 +72,4 @@ function ApiRequestPage<T>({
   return renderContent()
 }
 
-export default ApiRequestPage
+export default ApiRequestComponent

--- a/src/ExplorerRouter.test.tsx
+++ b/src/ExplorerRouter.test.tsx
@@ -14,12 +14,14 @@ import {
 } from './Pages/EventPages/__mocks__/EventPages'
 import { mockDiemInCirculationPageText } from './Pages/DiemInCirculationPage/__mocks__/DiemInCirculationPage'
 import { mockAccountPageText } from './Pages/AccountPage/__mocks__/AccountPage'
+import { mockLeaderboardPageText } from './Pages/LeaderboardPage/__mocks__/LeaderboardPage'
 
 jest.mock('./Pages/LandingPage/LandingPage')
 jest.mock('./Pages/TxnDetailsPage/TxnDetailsPage')
 jest.mock('./Pages/EventPages/EventPages')
 jest.mock('./Pages/DiemInCirculationPage/DiemInCirculationPage')
 jest.mock('./Pages/AccountPage/AccountPage')
+jest.mock('./Pages/LeaderboardPage/LeaderboardPage')
 
 function renderWithRouter(path: string) {
   const history = createMemoryHistory()
@@ -27,73 +29,80 @@ function renderWithRouter(path: string) {
   return render(
     <Router history={history}>
       <ExplorerRouter />
-    </Router>
+    </Router>,
   )
 }
 
 describe('ExplorerRouter', () => {
-  it('should render Landing page when path is /', async function () {
-    renderWithRouter('/')
-    expect(screen.getByRole('main').textContent).toContain(mockLandingPageText)
-  })
-  it('should render Transaction Details page when path is /txn/{?}', async function () {
-    const fakeId = 'some_id'
-    renderWithRouter(`/txn/${fakeId}`)
-    expect(screen.getByRole('main').textContent).toContain(
-      mockTxnDetailsPageText
-    )
-    expect(screen.getByRole('main').textContent).toContain(fakeId)
-  })
-  it('should render Mint Events page when path is /events/mint', async function () {
-    renderWithRouter('/events/mint')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockMintEventsPageText
-    )
-  })
-  it('should render Burn Events page when path is /events/burn', async function () {
-    renderWithRouter('/events/burn')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockBurnEventsPageText
-    )
-  })
-  it('should render Payment Events page when path is /events/payment', async function () {
-    renderWithRouter('/events/payment')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockPaymentEventsPageText
-    )
-  })
-  it('should render Gas Events page when path is /events/gas', async function () {
-    renderWithRouter('/events/gas')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockGasEventsPageText
-    )
-  })
-  it('should render Preburn Events page when path is /events/preburn', async function () {
-    renderWithRouter('/events/preburn')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockPreburnEventsPageText
-    )
-  })
-  it('should render Account Events Events page when path is /events/accountcreation', async function () {
-    renderWithRouter('/events/accountcreation')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockAccountCreationEventsPageText
-    )
-  })
-  it('should render Diem In Circulation page when path is /dieminciculation', async function () {
-    renderWithRouter('/diemincirculation')
-    expect(screen.getByRole('main').textContent).toContain(
-      mockDiemInCirculationPageText
-    )
-  })
-  it('should render Account page when path is /address/{?}', async function () {
-    const fakeId = 'some_id'
-    renderWithRouter(`/address/${fakeId}`)
-    expect(screen.getByRole('main').textContent).toContain(mockAccountPageText)
-    expect(screen.getByRole('main').textContent).toContain(fakeId)
-  })
-  it('should render 404 page when path is unknown', async function () {
-    renderWithRouter('/not_a_real_url')
-    expect(screen.getByRole('main').textContent).toContain('Page not found.')
-  })
+  [
+    {
+      name: 'Landing',
+      route: '/',
+      text: [mockLandingPageText],
+    },
+    {
+      name: 'Mint Events',
+      route: '/events/mint',
+      text: [mockMintEventsPageText],
+    },
+    {
+      name: 'Burn Events',
+      route: '/events/burn',
+      text: [mockBurnEventsPageText],
+    },
+    {
+      name: 'Payment Events',
+      route: '/events/payment',
+      text: [mockPaymentEventsPageText],
+    },
+    {
+      name: 'Gas Events',
+      route: '/events/gas',
+      text: [mockGasEventsPageText],
+    },
+    {
+      name: 'Preburn Events',
+      route: '/events/preburn',
+      text: [mockPreburnEventsPageText],
+    },
+    {
+      name: 'Account Creation Events',
+      route: '/events/accountcreation',
+      text: [mockAccountCreationEventsPageText],
+    },
+    {
+      name: 'Diem In Circulation',
+      route: '/diemincirculation',
+      text: [mockDiemInCirculationPageText],
+    },
+    {
+      name: 'Leaderboard',
+      route: '/leaderboard',
+      text: [mockLeaderboardPageText],
+    },
+    {
+      name: 'Transaction Details',
+      route: '/txn/some_id',
+      text: [mockTxnDetailsPageText, 'some_id'],
+    },
+    {
+      name: 'Account',
+      route: '/address/some_id',
+      text: [mockAccountPageText, 'some_id'],
+    },
+    {
+      name: '404',
+      route: '/not_a_real_url',
+      text: ['Page not found.'],
+    },
+  ]
+    .forEach(spec => {
+      it(`should render ${spec.name} page when path is ${spec.route}`, () => {
+        renderWithRouter(spec.route)
+        const textContent = screen.getByRole('main').textContent
+        spec.text.forEach(text => {
+          expect(textContent).toContain(text)
+        })
+      })
+    })
 })

--- a/src/ExplorerRouter.tsx
+++ b/src/ExplorerRouter.tsx
@@ -5,6 +5,7 @@ import NotFoundPage from './Pages/NotFoundPage'
 import eventPages from './Pages/EventPages/EventPages'
 import DiemIncirculationPage from './Pages/DiemInCirculationPage/DiemInCirculationPage'
 import AccountPage from './Pages/AccountPage/AccountPage'
+import LeaderboardPage from './Pages/LeaderboardPage/LeaderboardPage'
 
 export default function ExplorerRouter() {
   return (
@@ -22,6 +23,7 @@ export default function ExplorerRouter() {
       />
       <Route path="/diemincirculation" component={DiemIncirculationPage} />
       <Route path="/address/:address" component={AccountPage} />
+      <Route path='/leaderboard' component={LeaderboardPage}/>
       <Route component={NotFoundPage} />
     </Switch>
   )

--- a/src/MainWrapper.tsx
+++ b/src/MainWrapper.tsx
@@ -69,6 +69,9 @@ function MainWrapper(props: MainWrapperProps) {
                 <Link className="nav-link" to="/diemincirculation">
                   Diem-In-Circulation
                 </Link>
+                <Link className='nav-link' to='/leaderboard'>
+                  Leaderboard
+                </Link>
               </Nav>
             </Navbar.Collapse>
           </Container>

--- a/src/Pages/AccountPage/AccountPage.test.tsx
+++ b/src/Pages/AccountPage/AccountPage.test.tsx
@@ -42,20 +42,17 @@ const renderSubject = async (
 ) => {
   // @ts-ignore TS is bad at mocking
   getAccountResources.mockResolvedValue({
-    errors: null,
     data: resources,
   })
 
   // @ts-ignore TS is bad at mocking
   getAccountModules.mockResolvedValue({
-    errors: null,
     data: modules,
   })
 
   // @ts-ignore TS is bad at mocking
   postQueryToAnalyticsApi.mockResolvedValue({
-    errors: null,
-    data: transactions,
+    data: transactions
   })
 
   const mockHistory = {

--- a/src/Pages/AccountPage/AccountPage.tsx
+++ b/src/Pages/AccountPage/AccountPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../api_clients/AnalyticsQueries'
 import { DataOrErrors } from '../../api_clients/FetchTypes'
 import { TransactionVersion } from '../../TableComponents/Link'
-import Table from '../../Table'
+import Table, { ColumnWithAccessorDescriptor } from '../../Table'
 import MainWrapper from '../../MainWrapper'
 import JSONPretty from 'react-json-pretty'
 import React from 'react'
@@ -58,7 +58,7 @@ function UnsupportedAccountCard() {
 }
 
 const RecentTransactionsTable: React.FC<{ transactions: TransactionRow[] }> = ({ transactions }) => {
-  const columns = [
+  const columns: ColumnWithAccessorDescriptor<TransactionRow>[] = [
     {
       Header: 'Version',
       accessor: 'version',

--- a/src/Pages/AccountPage/AccountPage.tsx
+++ b/src/Pages/AccountPage/AccountPage.tsx
@@ -2,13 +2,10 @@ import { RouteComponentProps } from 'react-router-dom'
 import ApiRequestComponent from '../../ApiRequestComponent'
 import { getAccountModules, getAccountResources } from '../../api_clients/BlockchainRestClient'
 import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
-import {
-  transactionsBySenderAddressQuery,
-  transactionsQueryType
-} from '../../api_clients/AnalyticsQueries'
+import { transactionsBySenderAddressQuery, transactionsQueryType } from '../../api_clients/AnalyticsQueries'
 import { DataOrErrors } from '../../api_clients/FetchTypes'
 import { TransactionVersion } from '../../TableComponents/Link'
-import Table, { ColumnWithAccessorDescriptor } from '../../Table'
+import Table, { column } from '../../Table'
 import MainWrapper from '../../MainWrapper'
 import JSONPretty from 'react-json-pretty'
 import React from 'react'
@@ -23,10 +20,7 @@ import {
   Module,
   Resource,
 } from '../../api_clients/BlockchainRestTypes'
-import {
-  TransactionRow,
-  transformAnalyticsTransactionIntoTransaction
-} from '../Common/TransactionModel'
+import { TransactionRow, transformAnalyticsTransactionIntoTransaction } from '../Common/TransactionModel'
 
 interface AccountPageWithResponseProps {
   resources: Resource[]
@@ -58,27 +52,12 @@ function UnsupportedAccountCard() {
 }
 
 const RecentTransactionsTable: React.FC<{ transactions: TransactionRow[] }> = ({ transactions }) => {
-  const columns: ColumnWithAccessorDescriptor<TransactionRow>[] = [
-    {
-      Header: 'Version',
-      accessor: 'version',
-      Cell: TransactionVersion
-    },
-    {
-      Header: 'Timestamp',
-      accessor: 'commitTimestamp'
-    },
-    {
-      Header: 'Type',
-      accessor: 'txnType'
-    },
-    {
-      Header: 'Status',
-      accessor: 'status'
-    },
-  ]
-
-  return <Table columns={columns} data={transactions} id="recentTransactions"/>
+  return <Table columns={[
+    column('Version', 'version', TransactionVersion),
+    column('Timestamp', 'commitTimestamp'),
+    column('Type', 'txnType'),
+    column('Status', 'status'),
+  ]} data={transactions} id='recentTransactions' />
 }
 
 function AccountPageWithResponse({

--- a/src/Pages/AccountPage/AccountPage.tsx
+++ b/src/Pages/AccountPage/AccountPage.tsx
@@ -130,7 +130,7 @@ async function getAccountData(
   const modulesResponse = await getAccountModules(address)
   const recentTransactions = await postQueryToAnalyticsApi<transactionsQueryType>(transactionsBySenderAddressQuery(address), 'transactions')
 
-  if (resourcesResponse.errors || modulesResponse.errors || recentTransactions.errors) {
+  if ('errors' in resourcesResponse || 'errors' in modulesResponse || 'errors' in recentTransactions) {
     const allErrors = []
       // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
       .concat(resourcesResponse.errors)
@@ -140,17 +140,15 @@ async function getAccountData(
       .concat(recentTransactions.errors)
       .filter((error) => error !== null)
     return {
-      data: null,
       errors: allErrors,
     }
   } else {
     return {
       data: {
-        resources: resourcesResponse.data!,
-        modules: modulesResponse.data!,
-        transactions: recentTransactions.data!.map(transformAnalyticsTransactionIntoTransaction)
+        resources: resourcesResponse.data,
+        modules: modulesResponse.data,
+        transactions: recentTransactions.data.map(transformAnalyticsTransactionIntoTransaction)
       },
-      errors: null,
     }
   }
 }

--- a/src/Pages/AccountPage/AccountPage.tsx
+++ b/src/Pages/AccountPage/AccountPage.tsx
@@ -1,13 +1,10 @@
 import { RouteComponentProps } from 'react-router-dom'
-import ApiRequestPage from '../../ApiRequestPage'
-import {
-  getAccountModules,
-  getAccountResources,
-} from '../../api_clients/BlockchainRestClient'
+import ApiRequestComponent from '../../ApiRequestComponent'
+import { getAccountModules, getAccountResources } from '../../api_clients/BlockchainRestClient'
 import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
 import {
   transactionsBySenderAddressQuery,
-  transactionsQueryType,
+  transactionsQueryType
 } from '../../api_clients/AnalyticsQueries'
 import { DataOrErrors } from '../../api_clients/FetchTypes'
 import { TransactionVersion } from '../../TableComponents/Link'
@@ -28,7 +25,7 @@ import {
 } from '../../api_clients/BlockchainRestTypes'
 import {
   TransactionRow,
-  transformAnalyticsTransactionIntoTransaction,
+  transformAnalyticsTransactionIntoTransaction
 } from '../Common/TransactionModel'
 
 interface AccountPageWithResponseProps {
@@ -38,10 +35,8 @@ interface AccountPageWithResponseProps {
 }
 
 function accountIsSupported(data: AccountPageWithResponseProps) {
-  const hasStructs =
-    data.modules.length > 0 && data.modules[0].abi?.structs.length > 0
-  const hasMethods =
-    data.modules.length > 0 && data.modules[0].abi?.exposed_functions.length > 0
+  const hasStructs = data.modules.length > 0 && data.modules[0].abi?.structs.length > 0
+  const hasMethods = data.modules.length > 0 && data.modules[0].abi?.exposed_functions.length > 0
   const hasBalance = data.resources.some(isBalanceResource)
 
   return hasStructs || hasMethods || hasBalance
@@ -62,30 +57,28 @@ function UnsupportedAccountCard() {
   )
 }
 
-const RecentTransactionsTable: React.FC<{ transactions: TransactionRow[] }> = ({
-  transactions,
-}) => {
+const RecentTransactionsTable: React.FC<{ transactions: TransactionRow[] }> = ({ transactions }) => {
   const columns = [
     {
       Header: 'Version',
       accessor: 'version',
-      Cell: TransactionVersion,
+      Cell: TransactionVersion
     },
     {
       Header: 'Timestamp',
-      accessor: 'commitTimestamp',
+      accessor: 'commitTimestamp'
     },
     {
       Header: 'Type',
-      accessor: 'txnType',
+      accessor: 'txnType'
     },
     {
       Header: 'Status',
-      accessor: 'status',
+      accessor: 'status'
     },
   ]
 
-  return <Table columns={columns} data={transactions} id="recentTransactions" />
+  return <Table columns={columns} data={transactions} id="recentTransactions"/>
 }
 
 function AccountPageWithResponse({
@@ -97,67 +90,47 @@ function AccountPageWithResponse({
     <MainWrapper>
       <>
         <h1>Account Details</h1>
-        {!accountIsSupported(data) && <UnsupportedAccountCard />}
-        <Balances resources={data.resources} />
+        {!accountIsSupported(data) && <UnsupportedAccountCard/>}
+        <Balances resources={data.resources}/>
 
         <h2>Recent Transactions</h2>
-        <RecentTransactionsTable transactions={data.transactions} />
+        <RecentTransactionsTable transactions={data.transactions}/>
 
-        <SmartContractMethods modules={data.modules} />
-        <SmartContractStructs modules={data.modules} />
+        <SmartContractMethods modules={data.modules}/>
+        <SmartContractStructs modules={data.modules}/>
 
         <Card className="mb-5">
           <Card.Header>Sequence Number</Card.Header>
           <Card.Body id="sequenceNumber">
-            {
-              (
-                data.resources.find(
-                  isDiemAccountResource
-                ) as DiemAccountResource
-              )?.value.sequence_number
-            }
+            {(data.resources.find(isDiemAccountResource) as DiemAccountResource)?.value.sequence_number}
           </Card.Body>
         </Card>
 
         <Card className="mb-5">
           <Card.Header>Authentication Key</Card.Header>
           <Card.Body id="authenticationKey">
-            {
-              (
-                data.resources.find(
-                  isDiemAccountResource
-                ) as DiemAccountResource
-              )?.value.authentication_key
-            }
+            {(data.resources.find(isDiemAccountResource) as DiemAccountResource)?.value.authentication_key}
           </Card.Body>
         </Card>
 
         <h2>Raw Resources</h2>
-        <JSONPretty data={data.resources} id="rawResources" />
+        <JSONPretty data={data.resources} id="rawResources"/>
 
         <h2>Raw Smart Contracts</h2>
-        <JSONPretty data={data.modules} id="rawModules" />
+        <JSONPretty data={data.modules} id="rawModules"/>
       </>
     </MainWrapper>
   )
 }
 
 async function getAccountData(
-  address: string
+  address: string,
 ): Promise<DataOrErrors<AccountPageWithResponseProps>> {
   const resourcesResponse = await getAccountResources(address)
   const modulesResponse = await getAccountModules(address)
-  const recentTransactions =
-    await postQueryToAnalyticsApi<transactionsQueryType>(
-      transactionsBySenderAddressQuery(address),
-      'transactions'
-    )
+  const recentTransactions = await postQueryToAnalyticsApi<transactionsQueryType>(transactionsBySenderAddressQuery(address), 'transactions')
 
-  if (
-    resourcesResponse.errors ||
-    modulesResponse.errors ||
-    recentTransactions.errors
-  ) {
+  if (resourcesResponse.errors || modulesResponse.errors || recentTransactions.errors) {
     const allErrors = []
       // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
       .concat(resourcesResponse.errors)
@@ -175,9 +148,7 @@ async function getAccountData(
       data: {
         resources: resourcesResponse.data!,
         modules: modulesResponse.data!,
-        transactions: recentTransactions.data!.map(
-          transformAnalyticsTransactionIntoTransaction
-        ),
+        transactions: recentTransactions.data!.map(transformAnalyticsTransactionIntoTransaction)
       },
       errors: null,
     }
@@ -194,15 +165,15 @@ export default function AccountPage(props: AccountPageProps) {
   const nullData = {
     resources: [],
     modules: [],
-    transactions: [],
+    transactions: []
   }
 
   return (
-    <ApiRequestPage
+    <ApiRequestComponent
       request={getAccountData}
       args={[props.match.params.address.toUpperCase()]}
     >
-      <AccountPageWithResponse data={nullData} />
-    </ApiRequestPage>
+      <AccountPageWithResponse data={nullData}/>
+    </ApiRequestComponent>
   )
 }

--- a/src/Pages/Common/TransactionModel.tsx
+++ b/src/Pages/Common/TransactionModel.tsx
@@ -3,10 +3,10 @@ import { GraphQLTypes } from '../../../utils/Analytics_Hasura_Api_Zeus_Client/ze
 export interface TransactionRow {
   version: number
   expirationTimestamp: string | undefined
-  commitTimestamp: string | undefined
+  commitTimestamp: string
   sender: string | undefined
-  txnType: string | undefined
-  status: string | undefined
+  txnType: string
+  status: string
 }
 
 function getTransactionTypeFromEnum(txnType: number) {
@@ -18,6 +18,9 @@ function getTransactionTypeFromEnum(txnType: number) {
     case 3:
       return 'UserTransaction'
     case 4:
+      return 'Unknown'
+    default:
+      console.error(`Unknown transaction type value: ${txnType}`)
       return 'Unknown'
   }
 }
@@ -40,6 +43,9 @@ function getStatusFromEnum(status: number) {
       return 'DeserializationError'
     case 8:
       return 'PublishingFailure'
+    default:
+      console.error(`Unknown transaction status value: ${status}`)
+      return 'Unknown'
   }
 }
 

--- a/src/Pages/DiemInCirculationPage/DiemInCirculationPage.test.tsx
+++ b/src/Pages/DiemInCirculationPage/DiemInCirculationPage.test.tsx
@@ -20,20 +20,16 @@ const mockXusInCirculation = {
 }
 
 beforeEach(async () => {
-  postQueryToAnalyticsApi
-    // @ts-ignore TS is bad at mocking
-    .mockResolvedValueOnce({
-      errors: null,
-      data: {
-        diem_in_circulation_realtime_aggregates: [mockXusInCirculation],
-      },
-    })
-    .mockResolvedValueOnce({
-      errors: null,
-      data: {
-        diem_in_circulation_realtime_aggregates: [],
-      },
-    })
+  // @ts-ignore TS is bad at mocking
+  postQueryToAnalyticsApi.mockResolvedValueOnce({
+    data: {
+      diem_in_circulation_realtime_aggregates: [mockXusInCirculation]
+    }
+  }).mockResolvedValueOnce({
+    data: {
+      diem_in_circulation_realtime_aggregates: []
+    }
+  })
   render(
     <BrowserRouter>
       <DiemInCirculationPage />

--- a/src/Pages/DiemInCirculationPage/DiemInCirculationPage.tsx
+++ b/src/Pages/DiemInCirculationPage/DiemInCirculationPage.tsx
@@ -3,10 +3,7 @@ import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
 import MainWrapper from '../../MainWrapper'
 import Table from '../../Table'
 import React from 'react'
-import {
-  currencyInCirculationPageQuery,
-  currencyInCirculationPageQueryType,
-} from '../../api_clients/AnalyticsQueries'
+import { currencyInCirculationPageQuery, currencyInCirculationPageQueryType } from '../../api_clients/AnalyticsQueries'
 import { GraphQLTypes } from '../../../utils/Analytics_Hasura_Api_Zeus_Client/zeus'
 
 interface DiemCurrencies {
@@ -37,33 +34,19 @@ export default function DiemInCirculationPage() {
   return (
     <ApiRequestComponent
       request={async () => {
-        const xusOrErrors =
-          await postQueryToAnalyticsApi<currencyInCirculationPageQueryType>(
-            currencyInCirculationPageQuery('XUS')
-          )
-        const xdxOrErrors =
-          await postQueryToAnalyticsApi<currencyInCirculationPageQueryType>(
-            currencyInCirculationPageQuery('XDX')
-          )
-        if (xusOrErrors.errors || xdxOrErrors.errors) {
+        const xusOrErrors = await postQueryToAnalyticsApi<currencyInCirculationPageQueryType>(currencyInCirculationPageQuery('XUS'))
+        const xdxOrErrors = await postQueryToAnalyticsApi<currencyInCirculationPageQueryType>(currencyInCirculationPageQuery('XDX'))
+        if ('errors' in xusOrErrors || 'errors' in xdxOrErrors) {
           return {
-            data: null,
-            errors: []
-              // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
-              .concat(xusOrErrors.errors)
-              // @ts-ignore ☝️
-              .concat(xdxOrErrors.errors)
-              .filter((error) => error !== null),
+            // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
+            errors: [].concat(xusOrErrors.errors).concat(xdxOrErrors.errors).filter((error) => error !== null)
           }
         } else {
           return {
             data: {
-              xdx: xdxOrErrors.data!.diem_in_circulation_realtime_aggregates
-                ? xdxOrErrors.data!.diem_in_circulation_realtime_aggregates[0]
-                : [],
-              xus: xusOrErrors.data!.diem_in_circulation_realtime_aggregates[0],
+              xdx: xdxOrErrors.data.diem_in_circulation_realtime_aggregates ? xdxOrErrors.data.diem_in_circulation_realtime_aggregates[0] : [],
+              xus: xusOrErrors.data.diem_in_circulation_realtime_aggregates[0]
             },
-            errors: null,
           }
         }
       }}

--- a/src/Pages/DiemInCirculationPage/DiemInCirculationPage.tsx
+++ b/src/Pages/DiemInCirculationPage/DiemInCirculationPage.tsx
@@ -1,4 +1,4 @@
-import ApiRequestPage from '../../ApiRequestPage'
+import ApiRequestComponent from '../../ApiRequestComponent'
 import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
 import MainWrapper from '../../MainWrapper'
 import Table from '../../Table'
@@ -35,7 +35,7 @@ function DiemInCirculationPageWithResponse(props: { data: DiemCurrencies }) {
 
 export default function DiemInCirculationPage() {
   return (
-    <ApiRequestPage
+    <ApiRequestComponent
       request={async () => {
         const xusOrErrors =
           await postQueryToAnalyticsApi<currencyInCirculationPageQueryType>(
@@ -69,6 +69,6 @@ export default function DiemInCirculationPage() {
       }}
     >
       <DiemInCirculationPageWithResponse data={{ xus: [], xdx: [] }} />
-    </ApiRequestPage>
+    </ApiRequestComponent>
   )
 }

--- a/src/Pages/EventPages/EventPage.test.tsx
+++ b/src/Pages/EventPages/EventPage.test.tsx
@@ -40,7 +40,6 @@ const eventType = 'Arbitrary'
 beforeEach(async () => {
   // @ts-ignore TS is bad at mocking
   postQueryToAnalyticsApi.mockResolvedValue({
-    errors: null,
     data: [mockFakeEvent],
   })
   render(

--- a/src/Pages/EventPages/EventPage.tsx
+++ b/src/Pages/EventPages/EventPage.tsx
@@ -1,4 +1,4 @@
-import ApiRequestPage from '../../ApiRequestPage'
+import ApiRequestComponent from '../../ApiRequestComponent'
 import { postQueryToAnalyticsApi } from '../../api_clients/AnalyticsClient'
 import React from 'react'
 import MainWrapper from '../../MainWrapper'
@@ -7,23 +7,15 @@ import Table from '../../Table'
 interface EventPageProps {
   query: Object
   columns: {
-    Header: string
-    accessor: string
-    Cell?: React.FC<{ value: any }>
+    Header: string,
+    accessor: string,
+    Cell?: React.FC<{value:any}>
   }[]
   tableName: string
   eventType: string
 }
 
-function EventPageWithResponse({
-  data,
-  columns,
-  eventType,
-}: {
-  data: any[]
-  columns: EventPageProps['columns']
-  eventType: EventPageProps['eventType']
-}) {
+function EventPageWithResponse({ data, columns, eventType }: { data: any[], columns: EventPageProps['columns'], eventType: EventPageProps['eventType'] }) {
   return (
     <MainWrapper>
       <>
@@ -34,20 +26,15 @@ function EventPageWithResponse({
   )
 }
 
-const EventPage = ({
-  query,
-  columns,
-  tableName,
-  eventType,
-}: EventPageProps) => {
+const EventPage = ({ query, columns, tableName, eventType }: EventPageProps) => {
   return (
-    <ApiRequestPage request={() => postQueryToAnalyticsApi(query, tableName)}>
-      <EventPageWithResponse
-        data={[]}
-        columns={columns}
-        eventType={eventType}
-      />
-    </ApiRequestPage>
+    <ApiRequestComponent
+      request={() =>
+        postQueryToAnalyticsApi(query, tableName)
+      }
+    >
+      <EventPageWithResponse data={[]} columns={columns} eventType={eventType} />
+    </ApiRequestComponent>
   )
 }
 

--- a/src/Pages/LandingPage/LandingPage.test.tsx
+++ b/src/Pages/LandingPage/LandingPage.test.tsx
@@ -64,7 +64,6 @@ const renderSubject = async (
   })
   // @ts-ignore TS is bad at mocking
   postQueryToAnalyticsApi.mockResolvedValueOnce({
-    errors: null,
     data: [
       {
         total_burn_value: 700,

--- a/src/Pages/LandingPage/LandingPage.test.tsx
+++ b/src/Pages/LandingPage/LandingPage.test.tsx
@@ -56,12 +56,10 @@ const renderSubject = async (
 ) => {
   // @ts-ignore TS is bad at mocking
   postQueryToAnalyticsApi.mockResolvedValueOnce({
-    errors: null,
     data: { aggregate: { count: countTxnsInLast10m } },
   })
   // @ts-ignore TS is bad at mocking
   postQueryToAnalyticsApi.mockResolvedValueOnce({
-    errors: null,
     data: transactions,
   })
   // @ts-ignore TS is bad at mocking

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -98,6 +98,7 @@ function TransactionTable(props: { transactions: TransactionRow[] }) {
       ]} data={props.transactions} id='landingPageTransactions' />
     </>
   )
+}
 
 type LandingPageWithResponseProps = {
   data: {

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -4,7 +4,7 @@ import ApiRequestComponent from '../../ApiRequestComponent'
 import MainWrapper from '../../MainWrapper'
 import {
   TransactionRow,
-  transformAnalyticsTransactionIntoTransaction,
+  transformAnalyticsTransactionIntoTransaction
 } from '../Common/TransactionModel'
 import Table from '../../Table'
 import { useHistory } from 'react-router-dom'
@@ -17,7 +17,7 @@ import {
   countTransactionsInLast10MinutesType,
   LatestMintBurnNetQuery,
   transactionsQuery,
-  transactionsQueryType,
+  transactionsQueryType
 } from '../../api_clients/AnalyticsQueries'
 import ReactTooltip from 'react-tooltip'
 import { GraphQLTypes } from '../../../utils/Analytics_Hasura_Api_Zeus_Client/zeus'
@@ -36,56 +36,40 @@ function Wrapper(props: { children: ReactNode }) {
   )
 }
 
-type CurrentStatisticsCardProps = {
-  averageTps: number
-  totalMintValue: number
-  totalBurnValue: number
-  totalNetValue: number
-}
+type CurrentStatisticsCardProps = { averageTps: number, totalMintValue: number, totalBurnValue: number, totalNetValue: number}
 
-function CurrentStatisticsCard({
-  averageTps,
-  totalMintValue,
-  totalBurnValue,
-  totalNetValue,
-}: CurrentStatisticsCardProps) {
+function CurrentStatisticsCard({ averageTps, totalMintValue, totalBurnValue, totalNetValue }: CurrentStatisticsCardProps) {
   return (
-    <Card className="mb-5" data-testid="statisticsCard">
+    <Card className='mb-5' data-testid='statisticsCard'>
       <Card.Header>Current Statistics</Card.Header>
-      <Card.Body style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <section style={{}}>
-          <div data-tip data-for={'Transactions Per Second'}>
-            <span
-              style={{
-                fontWeight: 'bold',
-                textDecoration: 'underline',
-                textDecorationStyle: 'dotted',
-              }}
-            >
+      <Card.Body style = { { display: 'flex', justifyContent: 'space-between' }}>
+        <section style={{}} >
+          <div data-tip data-for={'Transactions Per Second'} >
+            <span style={{ fontWeight: 'bold', textDecoration: 'underline', textDecorationStyle: 'dotted' }}>
               TPS
             </span>
             <br />
             {new Intl.NumberFormat().format(averageTps)}
           </div>
-          <ReactTooltip id="Transactions Per Second" effect="solid">
+          <ReactTooltip id='Transactions Per Second' effect="solid">
             Transactions Per Second
           </ReactTooltip>
         </section>
-        <section style={{}}>
+        <section>
           <div>
             <span style={{ fontWeight: 'bold' }}>Total Mint Value</span>
-            <br />
+            <br/>
             {new Intl.NumberFormat().format(totalMintValue)} XUS
           </div>
         </section>
-        <section style={{}}>
+        <section>
           <div>
             <span style={{ fontWeight: 'bold' }}>Total Burn Value</span>
             <br />
             {new Intl.NumberFormat().format(totalBurnValue)} XUS
           </div>
         </section>
-        <section style={{}}>
+        <section>
           <div>
             <span style={{ fontWeight: 'bold' }}>Total Net Value</span>
             <br />
@@ -159,12 +143,7 @@ function LandingPageWithResponse(props: LandingPageWithResponseProps) {
           onKeyPress={handleSearch}
         />
       </InputGroup>
-      <CurrentStatisticsCard
-        averageTps={props.data.averageTps}
-        totalMintValue={props.data.totalMintAmount}
-        totalBurnValue={props.data.totalBurnAmount}
-        totalNetValue={props.data.totalNetAmount}
-      />
+      <CurrentStatisticsCard averageTps={props.data.averageTps} totalMintValue={props.data.totalMintAmount} totalBurnValue={props.data.totalBurnAmount} totalNetValue={props.data.totalNetAmount} />
       <TransactionTable transactions={props.data.recentTransactions} />
     </Wrapper>
   )
@@ -173,15 +152,13 @@ function LandingPageWithResponse(props: LandingPageWithResponseProps) {
 function transformAnalyticsTransactionsOrErrors(
   response: DataOrErrors<transactionsQueryType>
 ): DataOrErrors<TransactionRow[]> {
-  if (response.data) {
+  if ('data' in response) {
     return {
-      errors: null,
       data: response.data.map(transformAnalyticsTransactionIntoTransaction),
     }
   } else {
     return {
       errors: response.errors,
-      data: null,
     }
   }
 }
@@ -197,48 +174,24 @@ export default function LandingPage() {
   return (
     <ApiRequestComponent
       request={async () => {
-        const txnsInLast10m =
-          await postQueryToAnalyticsApi<countTransactionsInLast10MinutesType>(
-            countTransactionsInLast10Minutes(),
-            'transactions_aggregate'
-          )
-        const recentTxns = await postQueryToAnalyticsApi<transactionsQueryType>(
-          transactionsQuery(),
-          'transactions'
-        ).then(transformAnalyticsTransactionsOrErrors)
-        const latestMintBurnNetAmounts = await postQueryToAnalyticsApi<
-          GraphQLTypes['diem_in_circulation_realtime_aggregates'][]
-        >(LatestMintBurnNetQuery(), 'diem_in_circulation_realtime_aggregates')
+        const txnsInLast10m = await postQueryToAnalyticsApi<countTransactionsInLast10MinutesType>(countTransactionsInLast10Minutes(), 'transactions_aggregate')
+        const recentTxns = await postQueryToAnalyticsApi<transactionsQueryType>(transactionsQuery(), 'transactions').then(transformAnalyticsTransactionsOrErrors)
+        const latestMintBurnNetAmounts = await postQueryToAnalyticsApi<GraphQLTypes['diem_in_circulation_realtime_aggregates'][]>(LatestMintBurnNetQuery(), 'diem_in_circulation_realtime_aggregates')
 
-        if (
-          txnsInLast10m.errors ||
-          recentTxns.errors ||
-          latestMintBurnNetAmounts.errors
-        ) {
+        if ('errors' in txnsInLast10m || 'errors' in recentTxns || 'errors' in latestMintBurnNetAmounts) {
           return {
-            data: null,
-            errors: []
-              // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
-              .concat(txnsInLast10m.errors)
-              // @ts-ignore ☝️
-              .concat(recentTxns.errors)
-              // @ts-ignore ☝️
-              .concat(latestMintBurnNetAmounts.errors)
-              .filter((error) => error !== null),
+            // @ts-ignore nulls work in concat -- this will smash together the error arrays then remove nulls
+            errors: [].concat(txnsInLast10m.errors).concat(recentTxns.errors).concat(latestMintBurnNetAmounts.errors).filter((error) => error !== null)
           }
         } else {
           return {
             data: {
               recentTransactions: recentTxns.data,
-              averageTps: txnsInLast10m.data!.aggregate.count / 600,
-              totalMintAmount:
-                latestMintBurnNetAmounts.data![0]?.total_mint_value,
-              totalBurnAmount:
-                latestMintBurnNetAmounts.data![0]?.total_burn_value,
-              totalNetAmount:
-                latestMintBurnNetAmounts.data![0]?.total_net_value,
+              averageTps: txnsInLast10m.data.aggregate.count / 600,
+              totalMintAmount: latestMintBurnNetAmounts.data[0]?.total_mint_value,
+              totalBurnAmount: latestMintBurnNetAmounts.data[0]?.total_burn_value,
+              totalNetAmount: latestMintBurnNetAmounts.data[0]?.total_net_value
             },
-            errors: null,
           }
         }
       }}

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { Card, FormControl, InputGroup } from 'react-bootstrap'
 import React, { ReactNode } from 'react'
-import ApiRequestPage from '../../ApiRequestPage'
+import ApiRequestComponent from '../../ApiRequestComponent'
 import MainWrapper from '../../MainWrapper'
 import {
   TransactionRow,
@@ -195,7 +195,7 @@ export default function LandingPage() {
     totalNetAmount: NaN,
   }
   return (
-    <ApiRequestPage
+    <ApiRequestComponent
       request={async () => {
         const txnsInLast10m =
           await postQueryToAnalyticsApi<countTransactionsInLast10MinutesType>(
@@ -244,6 +244,6 @@ export default function LandingPage() {
       }}
     >
       <LandingPageWithResponse data={nullData} />
-    </ApiRequestPage>
+    </ApiRequestComponent>
   )
 }

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -27,7 +27,6 @@ function Wrapper(props: { children: ReactNode }) {
         <h2 className='mb-5' role='note'>
           Welcome To Diem Explorer
         </h2>
-        <h3 className='mb-2'>Recent Transactions</h3>
         {props.children}
       </>
     </MainWrapper>
@@ -95,7 +94,7 @@ function TransactionTable(props: { transactions: TransactionRow[] }) {
         column('Timestamp', 'commitTimestamp'),
         column('Type', 'txnType'),
         column('Status', 'status'),
-      ]} data={props.transactions} id='landingPageTransactions' />
+      ]} data={props.transactions} id='landingPageTransactions'/>
     </>
   )
 }
@@ -109,7 +108,6 @@ type LandingPageWithResponseProps = {
     totalNetAmount: number
   }
 }
-
 function LandingPageWithResponse(props: LandingPageWithResponseProps) {
   const history = useHistory()
 
@@ -144,8 +142,9 @@ function LandingPageWithResponse(props: LandingPageWithResponseProps) {
           onKeyPress={handleSearch}
         />
       </InputGroup>
-      <CurrentStatisticsCard averageTps={props.data.averageTps} totalMintValue={props.data.totalMintAmount} totalBurnValue={props.data.totalBurnAmount} totalNetValue={props.data.totalNetAmount} />
-      <TransactionTable transactions={props.data.recentTransactions} />
+      <CurrentStatisticsCard averageTps={props.data.averageTps} totalMintValue={props.data.totalMintAmount}
+        totalBurnValue={props.data.totalBurnAmount} totalNetValue={props.data.totalNetAmount}/>
+      <TransactionTable transactions={props.data.recentTransactions}/>
     </Wrapper>
   )
 }
@@ -197,7 +196,7 @@ export default function LandingPage() {
         }
       }}
     >
-      <LandingPageWithResponse data={nullData} />
+      <LandingPageWithResponse data={nullData}/>
     </ApiRequestComponent>
   )
 }

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -2,11 +2,8 @@ import { Card, FormControl, InputGroup } from 'react-bootstrap'
 import React, { ReactNode } from 'react'
 import ApiRequestComponent from '../../ApiRequestComponent'
 import MainWrapper from '../../MainWrapper'
-import {
-  TransactionRow,
-  transformAnalyticsTransactionIntoTransaction
-} from '../Common/TransactionModel'
-import Table, { ColumnWithAccessorDescriptor } from '../../Table'
+import { TransactionRow, transformAnalyticsTransactionIntoTransaction } from '../Common/TransactionModel'
+import Table, { column } from '../../Table'
 import { useHistory } from 'react-router-dom'
 import './LandingPage.css'
 import { TransactionVersion } from '../../TableComponents/Link'
@@ -17,7 +14,7 @@ import {
   countTransactionsInLast10MinutesType,
   LatestMintBurnNetQuery,
   transactionsQuery,
-  transactionsQueryType
+  transactionsQueryType,
 } from '../../api_clients/AnalyticsQueries'
 import ReactTooltip from 'react-tooltip'
 import { GraphQLTypes } from '../../../utils/Analytics_Hasura_Api_Zeus_Client/zeus'
@@ -27,9 +24,10 @@ function Wrapper(props: { children: ReactNode }) {
   return (
     <MainWrapper>
       <>
-        <h2 className="mb-5" role="note">
+        <h2 className='mb-5' role='note'>
           Welcome To Diem Explorer
         </h2>
+        <h3 className='mb-2'>Recent Transactions</h3>
         {props.children}
       </>
     </MainWrapper>
@@ -42,16 +40,23 @@ function CurrentStatisticsCard({ averageTps, totalMintValue, totalBurnValue, tot
   return (
     <Card className='mb-5' data-testid='statisticsCard'>
       <Card.Header>Current Statistics</Card.Header>
-      <Card.Body style = { { display: 'flex', justifyContent: 'space-between' }}>
-        <section style={{}} >
-          <div data-tip data-for={'Transactions Per Second'} >
-            <span style={{ fontWeight: 'bold', textDecoration: 'underline', textDecorationStyle: 'dotted' }}>
+      <Card.Body style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+      }}>
+        <section style={{}}>
+          <div data-tip data-for={'Transactions Per Second'}>
+            <span style={{
+              fontWeight: 'bold',
+              textDecoration: 'underline',
+              textDecorationStyle: 'dotted',
+            }}>
               TPS
             </span>
             <br />
             {new Intl.NumberFormat().format(averageTps)}
           </div>
-          <ReactTooltip id='Transactions Per Second' effect="solid">
+          <ReactTooltip id='Transactions Per Second' effect='solid'>
             Transactions Per Second
           </ReactTooltip>
         </section>
@@ -82,24 +87,18 @@ function CurrentStatisticsCard({ averageTps, totalMintValue, totalBurnValue, tot
 }
 
 function TransactionTable(props: { transactions: TransactionRow[] }) {
-  const columns: ColumnWithAccessorDescriptor<TransactionRow>[] = [
-    { Header: 'Version', accessor: 'version', Cell: TransactionVersion },
-    { Header: 'Timestamp', accessor: 'commitTimestamp' },
-    { Header: 'Type', accessor: 'txnType' },
-    { Header: 'Status', accessor: 'status' },
-  ]
-
   return (
     <>
       <h3 className="mb-2">Recent Transactions</h3>
-      <Table
-        columns={columns}
-        data={props.transactions}
-        id="landingPageTransactions"
-      />
+      <Table columns={[
+        column('Version', 'version', TransactionVersion),
+        column('Timestamp', 'commitTimestamp'),
+        column('Type', 'txnType'),
+        column('Status', 'status'),
+      ]} data={props.transactions} id='landingPageTransactions' />
     </>
   )
-}
+
 type LandingPageWithResponseProps = {
   data: {
     recentTransactions: TransactionRow[]
@@ -112,6 +111,7 @@ type LandingPageWithResponseProps = {
 
 function LandingPageWithResponse(props: LandingPageWithResponseProps) {
   const history = useHistory()
+
   function handleSearch(event: any) {
     // Enter Key
     if (event.key === 'Enter') {
@@ -136,10 +136,10 @@ function LandingPageWithResponse(props: LandingPageWithResponseProps) {
 
   return (
     <Wrapper>
-      <InputGroup className="mb-5">
+      <InputGroup className='mb-5'>
         <FormControl
-          placeholder="Search by Address or Transaction Version"
-          aria-label="Search by Address or Transaction Version"
+          placeholder='Search by Address or Transaction Version'
+          aria-label='Search by Address or Transaction Version'
           onKeyPress={handleSearch}
         />
       </InputGroup>
@@ -150,7 +150,7 @@ function LandingPageWithResponse(props: LandingPageWithResponseProps) {
 }
 
 function transformAnalyticsTransactionsOrErrors(
-  response: DataOrErrors<transactionsQueryType>
+  response: DataOrErrors<transactionsQueryType>,
 ): DataOrErrors<TransactionRow[]> {
   if ('data' in response) {
     return {
@@ -190,7 +190,7 @@ export default function LandingPage() {
               averageTps: txnsInLast10m.data.aggregate.count / 600,
               totalMintAmount: latestMintBurnNetAmounts.data[0]?.total_mint_value,
               totalBurnAmount: latestMintBurnNetAmounts.data[0]?.total_burn_value,
-              totalNetAmount: latestMintBurnNetAmounts.data[0]?.total_net_value
+              totalNetAmount: latestMintBurnNetAmounts.data[0]?.total_net_value,
             },
           }
         }

--- a/src/Pages/LandingPage/LandingPage.tsx
+++ b/src/Pages/LandingPage/LandingPage.tsx
@@ -6,7 +6,7 @@ import {
   TransactionRow,
   transformAnalyticsTransactionIntoTransaction
 } from '../Common/TransactionModel'
-import Table from '../../Table'
+import Table, { ColumnWithAccessorDescriptor } from '../../Table'
 import { useHistory } from 'react-router-dom'
 import './LandingPage.css'
 import { TransactionVersion } from '../../TableComponents/Link'
@@ -82,7 +82,7 @@ function CurrentStatisticsCard({ averageTps, totalMintValue, totalBurnValue, tot
 }
 
 function TransactionTable(props: { transactions: TransactionRow[] }) {
-  const columns = [
+  const columns: ColumnWithAccessorDescriptor<TransactionRow>[] = [
     { Header: 'Version', accessor: 'version', Cell: TransactionVersion },
     { Header: 'Timestamp', accessor: 'commitTimestamp' },
     { Header: 'Type', accessor: 'txnType' },

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import Top10TransactionsCard, { TopSentPaymentEvent } from './Top10TransactionsCard'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
+import moment from 'moment'
 
 jest.mock('../../../api_clients/AnalyticsClient', () => ({
   postQueryToAnalyticsApi: jest.fn(),
@@ -21,6 +22,13 @@ const renderSubject = async (
     <Top10TransactionsCard />
   </BrowserRouter>)
   await waitForElementToBeRemoved(screen.queryByRole('loading'))
+}
+
+async function elapsedMilliseconds(callback: Promise<any>): Promise<number> {
+  const timeBefore = moment().valueOf()
+  await callback
+  const timeAfter = moment().valueOf()
+  return timeAfter - timeBefore
 }
 
 describe('Top10TransactionsCard', () => {
@@ -78,9 +86,19 @@ describe('Top10TransactionsCard', () => {
     expect(cardBody!.rows[1].cells[1].textContent).toEqual('2')
   })
   it('should query the Analytics API correctly', async () => {
-    await renderSubject()
-    // TODO: how to handle time drift during this test?
+    const elapsedTime = await elapsedMilliseconds(renderSubject())
     const expectedQuery = top10Transactions('XUS')
-    expect(postQueryToAnalyticsApi).toHaveBeenCalledWith(expectedQuery, 'sentpayment_events')
+
+    expect(postQueryToAnalyticsApi).toHaveBeenCalledTimes(1)
+    // @ts-ignore TS is bad at mocking
+    const actualQuery = postQueryToAnalyticsApi.mock.calls[0][0]
+
+    const actualTimeMilliseconds = moment(actualQuery.sentpayment_events[0].where.commit_timestamp._gt).valueOf()
+    const expectedMilliseconds = moment(expectedQuery.sentpayment_events[0].where!.commit_timestamp._gt).valueOf()
+    expect(actualTimeMilliseconds).toBeCloseTo(expectedMilliseconds, elapsedTime)
+
+    delete actualQuery.sentpayment_events[0].where.commit_timestamp._gt
+    delete (expectedQuery.sentpayment_events[0].where!.commit_timestamp as any)._gt
+    expect(actualQuery).toEqual(expectedQuery)
   })
 })

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom' // provides `expect(...).toBeInTheDocument()`
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import Top10TransactionsCard from './Top10TransactionsCard'
+
+const renderSubject = async () => {
+  render(<BrowserRouter>
+    <Top10TransactionsCard />
+  </BrowserRouter>)
+  await waitForElementToBeRemoved(screen.queryByRole('loading'))
+}
+
+describe('Top10TransactionsCard', () => {
+  it('should have a title with an explanation', async () => {
+    await renderSubject()
+
+    const cardHeader = screen.queryByText('Top 10 Transactions (XUS)')
+    expect(cardHeader).toBeInTheDocument()
+    expect(cardHeader!.title).toContain('in the last 24 hours')
+  })
+  it('should have data', async () => {
+    // TODO: handle async rendering and the disappearance of the loading text
+    // TODO: mock the response
+    await renderSubject()
+
+    const cardBody: HTMLTableSectionElement | null = screen.queryByTestId('top-10-transactions')
+    expect(cardBody).toBeInTheDocument()
+    expect(cardBody!.rows).toHaveLength(1) // TODO: update this assertion
+    expect(cardBody!.rows[0].cells[0].textContent).toEqual('1')
+    expect(cardBody!.rows[0].cells[1].textContent).toEqual('12345')
+    expect(cardBody!.rows[0].cells[2].textContent).toEqual('54321')
+  })
+})

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -45,6 +45,20 @@ describe('Top10TransactionsCard', () => {
     expect(cardBody.rows[0].cells[1].textContent).toEqual('12345')
     expect(cardBody.rows[0].cells[2].textContent).toEqual('54321')
   })
+  it('should link to the corresponding transactions', async () => {
+    await renderSubject([
+      {
+        transaction_version: 12345,
+        amount: 54321,
+      },
+    ])
+
+    const transactionCell = screen.queryByTestId('top-10-transactions')!.querySelector('table tbody tr td:nth-child(2)')
+    expect(transactionCell).toBeInTheDocument()
+    const transactionLink: HTMLAnchorElement | null = transactionCell!.querySelector('a')
+    expect(transactionLink).toBeInTheDocument()
+    expect(transactionLink!.href).toMatch(/\/txn\/12345$/)
+  })
   it('should render the data in the order provided by the API', async () => {
     await renderSubject([
       {

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -1,9 +1,22 @@
 import '@testing-library/jest-dom' // provides `expect(...).toBeInTheDocument()`
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
-import Top10TransactionsCard from './Top10TransactionsCard'
+import Top10TransactionsCard, { TopSentPaymentEvent } from './Top10TransactionsCard'
+import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
+import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
 
-const renderSubject = async () => {
+jest.mock('../../../api_clients/AnalyticsClient', () => ({
+  postQueryToAnalyticsApi: jest.fn(),
+}))
+
+const renderSubject = async (
+  transactions: TopSentPaymentEvent[] = [],
+) => {
+  // @ts-ignore TS is bad at mocking
+  postQueryToAnalyticsApi.mockResolvedValue({
+    data: transactions,
+  })
+
   render(<BrowserRouter>
     <Top10TransactionsCard />
   </BrowserRouter>)
@@ -11,6 +24,11 @@ const renderSubject = async () => {
 }
 
 describe('Top10TransactionsCard', () => {
+  beforeEach(() => {
+    // @ts-ignore TS is bad at mocking
+    postQueryToAnalyticsApi.mockReset()
+  })
+
   it('should have a title with an explanation', async () => {
     await renderSubject()
 
@@ -18,16 +36,47 @@ describe('Top10TransactionsCard', () => {
     expect(cardHeader).toBeInTheDocument()
     expect(cardHeader!.title).toContain('in the last 24 hours')
   })
-  it('should have data', async () => {
-    // TODO: handle async rendering and the disappearance of the loading text
-    // TODO: mock the response
-    await renderSubject()
+  it('should render the data', async () => {
+    await renderSubject([
+      {
+        transaction_version: 12345,
+        amount: 54321,
+      },
+    ])
 
-    const cardBody: HTMLTableSectionElement | null = screen.queryByTestId('top-10-transactions')
-    expect(cardBody).toBeInTheDocument()
-    expect(cardBody!.rows).toHaveLength(1) // TODO: update this assertion
-    expect(cardBody!.rows[0].cells[0].textContent).toEqual('1')
-    expect(cardBody!.rows[0].cells[1].textContent).toEqual('12345')
-    expect(cardBody!.rows[0].cells[2].textContent).toEqual('54321')
+    const table: HTMLTableElement | null = screen.queryByTestId('top-10-transactions')
+    expect(table).toBeInTheDocument()
+    const cardBody = table!.tBodies.item(0)!
+    expect(cardBody.rows).toHaveLength(1)
+    expect(cardBody.rows[0].cells[0].textContent).toEqual('1')
+    expect(cardBody.rows[0].cells[1].textContent).toEqual('12345')
+    expect(cardBody.rows[0].cells[2].textContent).toEqual('54321')
+  })
+  it('should render the data in the order provided by the API', async () => {
+    await renderSubject([
+      {
+        transaction_version: 1,
+        amount: 1000,
+      },
+      {
+        transaction_version: 2,
+        amount: 2000,
+      },
+    ])
+
+    const table: HTMLTableElement = screen.queryByTestId('top-10-transactions')!
+    const cardBody = table.tBodies.item(0)!
+    expect(cardBody!.rows).toHaveLength(2)
+    expect(cardBody!.rows[0].cells[1].textContent).toEqual('1')
+    expect(cardBody!.rows[1].cells[1].textContent).toEqual('2')
+  })
+  it('should query the Analytics API correctly', async () => {
+    await renderSubject()
+    // TODO: how to handle time drift during this test?
+    const expectedQuery = top10Transactions('XUS')
+    expect(postQueryToAnalyticsApi).toHaveBeenCalledWith(expectedQuery, 'sentpayment_events')
+  })
+  describe('when there is an error', () => {
+    // TODO
   })
 })

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -76,7 +76,4 @@ describe('Top10TransactionsCard', () => {
     const expectedQuery = top10Transactions('XUS')
     expect(postQueryToAnalyticsApi).toHaveBeenCalledWith(expectedQuery, 'sentpayment_events')
   })
-  describe('when there is an error', () => {
-    // TODO
-  })
 })

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -29,13 +29,6 @@ describe('Top10TransactionsCard', () => {
     postQueryToAnalyticsApi.mockReset()
   })
 
-  it('should have a title with an explanation', async () => {
-    await renderSubject()
-
-    const cardHeader = screen.queryByText('Top 10 Transactions (XUS)')
-    expect(cardHeader).toBeInTheDocument()
-    expect(cardHeader!.title).toContain('in the last 24 hours')
-  })
   it('should render the data', async () => {
     await renderSubject([
       {
@@ -44,7 +37,7 @@ describe('Top10TransactionsCard', () => {
       },
     ])
 
-    const table: HTMLTableElement | null = screen.queryByTestId('top-10-transactions')
+    const table: HTMLTableElement | null | undefined = screen.queryByTestId('top-10-transactions')?.querySelector('table')
     expect(table).toBeInTheDocument()
     const cardBody = table!.tBodies.item(0)!
     expect(cardBody.rows).toHaveLength(1)
@@ -64,7 +57,7 @@ describe('Top10TransactionsCard', () => {
       },
     ])
 
-    const table: HTMLTableElement = screen.queryByTestId('top-10-transactions')!
+    const table: HTMLTableElement = screen.queryByTestId('top-10-transactions')!.querySelector('table')!
     const cardBody = table.tBodies.item(0)!
     expect(cardBody!.rows).toHaveLength(2)
     expect(cardBody!.rows[0].cells[1].textContent).toEqual('1')

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -46,7 +46,7 @@ async function getTopTransactions(currency: KnownCurrency): Promise<DataOrErrors
   if ('data' in result) {
     return { data: { topPayments: result.data } }
   } else {
-    throw new Error('Not implemented')
+    return result
   }
 }
 

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -1,4 +1,4 @@
-import ApiRequestComponent from '../../../ApiRequestComponent'
+import ApiRequestComponent, { PlainErrorComponent, PlainLoadingComponent } from '../../../ApiRequestComponent'
 import { DataOrErrors } from '../../../api_clients/FetchTypes'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
@@ -60,7 +60,12 @@ async function getTopTransactions(currency: KnownCurrency): Promise<DataOrErrors
 export default function Top10TransactionsCard() {
   return (
     <Card data-testid='top-10-transactions'>
-      <ApiRequestComponent request={getTopTransactions} args={['XUS']}>
+      <ApiRequestComponent
+        request={getTopTransactions}
+        args={['XUS']}
+        errorComponent={<PlainErrorComponent />}
+        loadingComponent={<PlainLoadingComponent />}
+      >
         <Top10TransactionsTable data={{ topPayments: [] }} />
       </ApiRequestComponent>
     </Card>

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -1,0 +1,31 @@
+// TODO: give this some params
+import ApiRequestComponent from '../../../ApiRequestComponent'
+
+function Top10TransactionsTableBody({ data }: { data: unknown[] }) {
+  console.log(data)
+  return (<tbody data-testid='top-10-transactions' />)
+}
+
+export default function Top10TransactionsCard() {
+  return (
+    <section>
+      <table>
+        <thead>
+        <tr>
+          <td colSpan={3}>
+            <h3 title='10 largest XUS transactions in the last 24 hours'>Top 10 Transactions (XUS)</h3>
+          </td>
+        </tr>
+        </thead>
+        <ApiRequestComponent request={() => Promise.resolve({
+          data: [{
+            transaction_version: 12345,
+            amount: 54321,
+          }],
+          errors: null,
+        })}>
+          <Top10TransactionsTableBody data={[]} />
+        </ApiRequestComponent>
+      </table>
+    </section>)
+}

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -3,6 +3,9 @@ import { DataOrErrors } from '../../../api_clients/FetchTypes'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
 import { KnownCurrency } from '../../../api_clients/BlockchainRestTypes'
+import { Card } from 'react-bootstrap'
+import Table from '../../../Table'
+import ReactTooltip from 'react-tooltip'
 
 export interface TopSentPaymentEvent {
   // eslint-disable-next-line camelcase
@@ -14,30 +17,43 @@ type Top10TransactionsTableProps = { topPayments: TopSentPaymentEvent[] };
 
 function Top10TransactionsTable({ data }: { data: Top10TransactionsTableProps }) {
   const { topPayments } = data
+  const paymentData = topPayments.map(({
+    // eslint-disable-next-line camelcase
+    transaction_version,
+    amount,
+  }, index) => ({
+    transactionVersion: transaction_version,
+    amount,
+    rank: index + 1,
+  }))
   return (
-    <table data-testid='top-10-transactions'>
-      <thead>
-        <tr>
-          <td colSpan={3}>
-            <h3 title='10 largest XUS transactions in the last 24 hours'>Top 10 Transactions (XUS)</h3>
-          </td>
-        </tr>
-        <tr>
-          <td>Ranking</td>
-          <td>Version</td>
-          <td>Amount (XUS)</td>
-        </tr>
-      </thead>
-      <tbody>{
-        topPayments.map((transaction, index) => (
-          <tr key={index}>
-            <td>{index + 1}</td>
-            <td>{transaction.transaction_version}</td>
-            <td>{transaction.amount}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <>
+      <Card.Header>
+        <div data-tip data-for='top-10-definition-xus'>
+          Top 10 Transactions (XUS)
+        </div>
+        <ReactTooltip id='top-10-definition-xus'>
+          10 largest transactions in XUS in the last 24 hours
+        </ReactTooltip>
+        { /* TODO: display a tooltip explaining this */}
+      </Card.Header>
+      <Card.Body>
+        <Table columns={[
+          {
+            Header: 'Ranking',
+            accessor: 'rank',
+          },
+          {
+            Header: 'Version',
+            accessor: 'transactionVersion',
+          },
+          {
+            Header: 'Amount (XUS)',
+            accessor: 'amount',
+          },
+        ]} data={paymentData} />
+      </Card.Body>
+    </>
   )
 }
 
@@ -52,9 +68,10 @@ async function getTopTransactions(currency: KnownCurrency): Promise<DataOrErrors
 
 export default function Top10TransactionsCard() {
   return (
-    <section>
+    <Card data-testid='top-10-transactions'>
       <ApiRequestComponent request={getTopTransactions} args={['XUS']}>
         <Top10TransactionsTable data={{ topPayments: [] }} />
       </ApiRequestComponent>
-    </section>)
+    </Card>
+  )
 }

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -4,8 +4,9 @@ import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
 import { KnownCurrency } from '../../../api_clients/BlockchainRestTypes'
 import { Card } from 'react-bootstrap'
-import Table from '../../../Table'
+import Table, { column } from '../../../Table'
 import ReactTooltip from 'react-tooltip'
+import { TransactionVersion } from '../../../TableComponents/Link'
 
 export interface TopSentPaymentEvent {
   // eslint-disable-next-line camelcase
@@ -22,7 +23,7 @@ function Top10TransactionsTable({ data }: { data: Top10TransactionsTableProps })
     transaction_version,
     amount,
   }, index) => ({
-    transactionVersion: transaction_version,
+    version: transaction_version,
     amount,
     rank: index + 1,
   }))
@@ -35,22 +36,12 @@ function Top10TransactionsTable({ data }: { data: Top10TransactionsTableProps })
         <ReactTooltip id='top-10-definition-xus'>
           10 largest transactions in XUS in the last 24 hours
         </ReactTooltip>
-        { /* TODO: display a tooltip explaining this */}
       </Card.Header>
       <Card.Body>
         <Table columns={[
-          {
-            Header: 'Ranking',
-            accessor: 'rank',
-          },
-          {
-            Header: 'Version',
-            accessor: 'transactionVersion',
-          },
-          {
-            Header: 'Amount (XUS)',
-            accessor: 'amount',
-          },
+          column('Ranking', 'rank'),
+          column('Version', 'version', TransactionVersion),
+          column('Amount(XUS)', 'amount'),
         ]} data={paymentData} />
       </Card.Body>
     </>

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -41,7 +41,7 @@ function Top10TransactionsTable({ data }: { data: Top10TransactionsTableProps })
         <Table columns={[
           column('Ranking', 'rank'),
           column('Version', 'version', TransactionVersion),
-          column('Amount(XUS)', 'amount'),
+          column('Amount (XUS)', 'amount'),
         ]} data={paymentData} />
       </Card.Body>
     </>

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -22,7 +22,6 @@ export default function Top10TransactionsCard() {
             transaction_version: 12345,
             amount: 54321,
           }],
-          errors: null,
         })}>
           <Top10TransactionsTableBody data={[]} />
         </ApiRequestComponent>

--- a/src/Pages/LeaderboardPage/Cards/__mocks__/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/__mocks__/Top10TransactionsCard.tsx
@@ -1,0 +1,9 @@
+export const mockTop10TransactionsCardText = 'These are the top 10 transactions for some currency or other.'
+const mockTop10TransactionsCard = () => (
+  <div
+    data-testid='top-10-transactions'
+  >
+    {mockTop10TransactionsCardText}
+  </div>
+)
+export default mockTop10TransactionsCard

--- a/src/Pages/LeaderboardPage/LeaderboardPage.test.tsx
+++ b/src/Pages/LeaderboardPage/LeaderboardPage.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom' // provides `expect(...).toBeInTheDocument()`
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import LeaderboardPage from './LeaderboardPage'
+import { mockTop10TransactionsCardText } from './Cards/__mocks__/Top10TransactionsCard'
+
+jest.mock('./Cards/Top10TransactionsCard')
+
+const renderSubject = async () => {
+  render(<BrowserRouter>
+    <LeaderboardPage />
+  </BrowserRouter>)
+}
+
+describe('LeaderboardPage', () => {
+  it('should have a page header', async () => {
+    await renderSubject()
+    const pageHeader = screen.queryByTestId('leaderboard-page-header')
+    expect(pageHeader).toBeInTheDocument()
+    expect(pageHeader!.textContent).toContain('Diem Leaderboard')
+  })
+  it('should display the top 10 transactions in the past 24 hours', async () => {
+    await renderSubject()
+    const top10TransactionsCard = screen.queryByTestId('top-10-transactions')
+    expect(top10TransactionsCard).toBeInTheDocument()
+    expect(top10TransactionsCard!.textContent).toContain(mockTop10TransactionsCardText)
+  })
+})

--- a/src/Pages/LeaderboardPage/LeaderboardPage.tsx
+++ b/src/Pages/LeaderboardPage/LeaderboardPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Top10TransactionsCard from './Cards/Top10TransactionsCard'
+import MainWrapper from '../../MainWrapper'
+
+export default function LeaderboardPage() {
+  return <MainWrapper>
+    <main>
+      <header data-testid='leaderboard-page-header'><h2>Diem Leaderboard</h2></header>
+      <Top10TransactionsCard />
+    </main>
+  </MainWrapper>
+}

--- a/src/Pages/LeaderboardPage/__mocks__/LeaderboardPage.tsx
+++ b/src/Pages/LeaderboardPage/__mocks__/LeaderboardPage.tsx
@@ -1,0 +1,5 @@
+export const mockLeaderboardPageText = 'This is the leaderboard!'
+const mockLeaderboardPage = () => (
+  <div role='main'>{mockLeaderboardPageText}</div>
+)
+export default mockLeaderboardPage

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
@@ -86,7 +86,6 @@ const renderWithTransaction = async (
 ) => {
   // @ts-ignore TS is bad at mocking
   getBlockchainTransaction.mockResolvedValue({
-    errors: null,
     data: txn,
   })
   const mockHistory = {

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.tsx
@@ -1,4 +1,4 @@
-import ApiRequestPage from '../../ApiRequestPage'
+import ApiRequestComponent from '../../ApiRequestComponent'
 import React from 'react'
 import {
   BlockchainTransaction,
@@ -119,12 +119,12 @@ interface TxnDetailsPageProps
 
 export default function TxnDetailsPage(props: TxnDetailsPageProps) {
   return (
-    <ApiRequestPage
+    <ApiRequestComponent
       request={() => {
         return getBlockchainTransaction(props.match.params.version)
       }}
     >
       <TxnDetailsPageWithResponse data={undefined} />
-    </ApiRequestPage>
+    </ApiRequestComponent>
   )
 }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -5,29 +5,35 @@ import React from 'react'
 type ColumnWithAccessorDescriptor<T, K extends keyof T> = {
   Header: string
   accessor: K
-  Cell?: React.FC<{value: T[K]}>
+  Cell?: React.FC<{ value: T[K] }>
 }
 
 export function column<C>(header: string, accessor: keyof C, cell?: React.FC<{ value: C[typeof accessor] }>) {
-  return {
-    Header: header,
-    accessor,
-    Cell: cell,
+  if (cell === undefined) {
+    return {
+      Header: header,
+      accessor,
+    }
+  } else {
+    return {
+      Header: header,
+      accessor,
+      Cell: cell,
+    }
   }
 }
 
-type TableProps<T extends { [key: string]: any }> = {
+type TableProps<T> = {
   columns: ColumnWithAccessorDescriptor<T, keyof T>[]
   data: T[]
   className?: string
   id?: string
 }
 
-export default function Table<T>(props: TableProps<T>) {
+export default function Table<T extends object>(props: TableProps<T>) {
   const { columns, data, className = '', id = '' } = props
 
-  // @ts-ignore (Tolerate a deficiency in library type)
-  const useTableOptions: TableOptions = { columns, data }
+  const useTableOptions: TableOptions<T> = { columns, data }
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(useTableOptions, useFilters, useSortBy)
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -2,14 +2,22 @@ import { useTable, useFilters, useSortBy, TableOptions } from 'react-table'
 import BTable from 'react-bootstrap/Table'
 import React from 'react'
 
-export type ColumnWithAccessorDescriptor<T> = {
+type ColumnWithAccessorDescriptor<T, K extends keyof T> = {
   Header: string
-  accessor: keyof T
-  Cell?: React.FC<{value:any}>
+  accessor: K
+  Cell?: React.FC<{value: T[K]}>
 }
 
-type TableProps<T> = {
-  columns: ColumnWithAccessorDescriptor<T>[]
+export function column<C>(header: string, accessor: keyof C, cell?: React.FC<{ value: C[typeof accessor] }>) {
+  return {
+    Header: header,
+    accessor,
+    Cell: cell,
+  }
+}
+
+type TableProps<T extends { [key: string]: any }> = {
+  columns: ColumnWithAccessorDescriptor<T, keyof T>[]
   data: T[]
   className?: string
   id?: string

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,19 +1,21 @@
 import { useTable, useFilters, useSortBy, TableOptions } from 'react-table'
 import BTable from 'react-bootstrap/Table'
+import React from 'react'
 
-type ColumnWithAccessorDescriptor = {
+export type ColumnWithAccessorDescriptor<T> = {
   Header: string
-  accessor: string
+  accessor: keyof T
+  Cell?: React.FC<{value:any}>
 }
 
-interface TableProps {
-  columns: Array<ColumnWithAccessorDescriptor>
-  data: any[]
+type TableProps<T> = {
+  columns: ColumnWithAccessorDescriptor<T>[]
+  data: T[]
   className?: string
   id?: string
 }
 
-export default function Table(props: TableProps) {
+export default function Table<T>(props: TableProps<T>) {
   const { columns, data, className = '', id = '' } = props
 
   // @ts-ignore (Tolerate a deficiency in library type)

--- a/src/TableComponents/Link.tsx
+++ b/src/TableComponents/Link.tsx
@@ -21,11 +21,19 @@ export const Link =
     }
 Link.displayName = 'DiemExplorerLink'
 
-export const TransactionVersion: React.FC<{ value: string }> = (props: {
-  value: string
-}) => {
-  return Link({ className: 'transaction-link', linkPrefix: '/txn/' })(props)
+export const TransactionVersion: React.FC<{ value?: string | number }> = (props: { value?: string | number }) => {
+  if (!('value' in props)) {
+    return <></>
+  }
+  return Link({
+    className: 'transaction-link',
+    linkPrefix: '/txn/',
+  })({ ...props, value: props.value!.toString() })
 }
+
 export function AccountAddress(props: { value: string }) {
-  return Link({ className: 'address-link', linkPrefix: '/address/' })(props)
+  return Link({
+    className: 'address-link',
+    linkPrefix: '/address/',
+  })(props)
 }

--- a/src/api_clients/AnalyticsClient.test.ts
+++ b/src/api_clients/AnalyticsClient.test.ts
@@ -9,7 +9,7 @@ const server = setupIntegrationTestApiServer()
 describe('Analytics Client', function () {
   it('should call .json before then getting the data out of the data key before returning', async function () {
     const goodAnalyticsResponse = { data: { key: 'any string we want here' } }
-    const expected = { data: goodAnalyticsResponse.data.key, errors: null }
+    const expected = { data: goodAnalyticsResponse.data.key }
     setAnalyticsApiResponse(server, goodAnalyticsResponse)
     const result = await postQueryToAnalyticsApi<string>(
       "the query doesn't matter since we're mocking the service workers (msw)",
@@ -23,7 +23,6 @@ describe('Analytics Client', function () {
       errors: [{ message: 'This is a good error !!' }],
     }
     const expected = {
-      data: null,
       errors: [{ message: badAnalyticsResponse.errors[0].message }],
     }
     setAnalyticsApiResponse(server, badAnalyticsResponse)
@@ -37,7 +36,6 @@ describe('Analytics Client', function () {
   it('should pass network errors through like any other error', async function () {
     const error = 'The internet went boom 💥'
     const expected = {
-      data: null,
       errors: [
         {
           message: `request to http://localhost:8888/v1/graphql failed, reason: ${error}`,

--- a/src/api_clients/AnalyticsClient.ts
+++ b/src/api_clients/AnalyticsClient.ts
@@ -12,7 +12,6 @@ export const postQueryToAnalyticsApi = async <T>(
     const gqlResponse = await Gql.query(query)
 
     return {
-      errors: null,
       // @ts-ignore property accessor syntax breaks the code here
       data: tableName ? gqlResponse[tableName] : gqlResponse,
     }
@@ -20,12 +19,10 @@ export const postQueryToAnalyticsApi = async <T>(
     if ('response' in err) {
       return {
         errors: [...err.response.errors],
-        data: null,
       }
     } else {
       return {
         errors: [{ message: err.message }],
-        data: null,
       }
     }
   }

--- a/src/api_clients/AnalyticsQueries.ts
+++ b/src/api_clients/AnalyticsQueries.ts
@@ -111,7 +111,7 @@ export function accountcreationEventsQuery() {
     accounts: [
       {
         limit: 10,
-        order_by: [{ transaction_version: order_by.desc }]
+        order_by: [{ transaction_version: order_by.desc }],
       },
       {
         transaction_version: true,
@@ -203,7 +203,7 @@ export function transactionsBySenderAddressQuery(senderAddress: string) {
 
 // eslint-disable-next-line camelcase
 export type currencyInCirculationPageQueryType = { diem_in_circulation_realtime_aggregates: ['diem_in_circulation_realtime_aggregates'][] }
-export function currencyInCirculationPageQuery(currency : string) {
+export function currencyInCirculationPageQuery(currency: KnownCurrency) {
   return {
     diem_in_circulation_realtime_aggregates: [
       {

--- a/src/api_clients/AnalyticsQueries.ts
+++ b/src/api_clients/AnalyticsQueries.ts
@@ -1,13 +1,10 @@
-/* eslint-disable camelcase */
-import {
-  GraphQLTypes,
-  order_by,
-} from '../../utils/Analytics_Hasura_Api_Zeus_Client/zeus'
+// eslint-disable-next-line camelcase
+import { GraphQLTypes, order_by } from '../../utils/Analytics_Hasura_Api_Zeus_Client/zeus'
 import moment from 'moment'
+import { KnownCurrency } from './BlockchainRestTypes'
 import { getCanonicalAddress } from '../utils'
 
-export type mintEventsQueryType =
-  GraphQLTypes['query_root']['receivedmint_events']
+export type mintEventsQueryType = GraphQLTypes['query_root']['receivedmint_events']
 export function mintEventsQuery() {
   return {
     receivedmint_events: [
@@ -47,8 +44,7 @@ export function burnEventsQuery() {
   }
 }
 
-export type paymentEventsQueryType =
-  GraphQLTypes['query_root']['sentpayment_events']
+export type paymentEventsQueryType = GraphQLTypes['query_root']['sentpayment_events']
 export function paymentEventsQuery() {
   return {
     sentpayment_events: [
@@ -90,8 +86,7 @@ export function gasEventsQuery() {
   }
 }
 
-export type preburnEventsQueryType =
-  GraphQLTypes['query_root']['preburn_events']
+export type preburnEventsQueryType = GraphQLTypes['query_root']['preburn_events']
 export function preburnEventsQuery() {
   return {
     preburn_events: [
@@ -110,14 +105,13 @@ export function preburnEventsQuery() {
   }
 }
 
-export type accountcreationEventsQueryType =
-  GraphQLTypes['query_root']['accounts']
+export type accountcreationEventsQueryType = GraphQLTypes['query_root']['accounts']
 export function accountcreationEventsQuery() {
   return {
     accounts: [
       {
         limit: 10,
-        order_by: [{ transaction_version: order_by.desc }],
+        order_by: [{ transaction_version: order_by.desc }]
       },
       {
         transaction_version: true,
@@ -208,12 +202,8 @@ export function transactionsBySenderAddressQuery(senderAddress: string) {
 }
 
 // eslint-disable-next-line camelcase
-export type currencyInCirculationPageQueryType = {
-  diem_in_circulation_realtime_aggregates: [
-    'diem_in_circulation_realtime_aggregates'
-  ][]
-}
-export function currencyInCirculationPageQuery(currency: string) {
+export type currencyInCirculationPageQueryType = { diem_in_circulation_realtime_aggregates: ['diem_in_circulation_realtime_aggregates'][] }
+export function currencyInCirculationPageQuery(currency : string) {
   return {
     diem_in_circulation_realtime_aggregates: [
       {
@@ -230,9 +220,7 @@ export function currencyInCirculationPageQuery(currency: string) {
   }
 }
 
-export type countTransactionsInLast10MinutesType = {
-  aggregate: { count: number }
-}
+export type countTransactionsInLast10MinutesType = { aggregate: { count: number } }
 export function countTransactionsInLast10Minutes() {
   const TEN_MINUTES_AGO = moment.utc().subtract(10, 'minutes').format()
   return {
@@ -245,6 +233,26 @@ export function countTransactionsInLast10Minutes() {
         aggregate: {
           count: [{}, true],
         },
+      },
+    ],
+  }
+}
+
+export function top10Transactions(currency: KnownCurrency) {
+  const TWENTY_FOUR_HOURS_AGO = moment.utc().subtract(1, 'days').format()
+  return {
+    sentpayment_events: [
+      {
+        limit: 10,
+        where: {
+          commit_timestamp: { _gt: TWENTY_FOUR_HOURS_AGO },
+          currency: { _eq: currency },
+        },
+        order_by: [{ transaction_version: order_by.desc }],
+      },
+      {
+        amount: true,
+        transaction_version: true,
       },
     ],
   }

--- a/src/api_clients/BlockchainJsonRpcClient.test.ts
+++ b/src/api_clients/BlockchainJsonRpcClient.test.ts
@@ -77,7 +77,6 @@ describe('Blockchain JSON RPC Client', function () {
   it('should pass data through', async function () {
     const expected = {
       data: { ...goodBlockchainResponse.result[0] },
-      errors: null,
     }
     setJsonRpcBlockchainApiResponse(server, goodBlockchainResponse)
     const result = await getBlockchainTransaction(
@@ -87,7 +86,6 @@ describe('Blockchain JSON RPC Client', function () {
   })
   it('should pass errors through', async function () {
     const expected = {
-      data: null,
       errors: [{ message: "Invalid params for method 'get_transactions'" }],
     }
     setJsonRpcBlockchainApiResponse(server, badBlockchainResponse)
@@ -100,7 +98,6 @@ describe('Blockchain JSON RPC Client', function () {
   it('should pass network errors through like any other error', async function () {
     const error = 'The internet went boom 💥'
     const expected = {
-      data: null,
       errors: [
         {
           message: `FetchError: request to https://fn0.premainnet.aosdev.diem.com/v1 failed, reason: ${error}`,

--- a/src/api_clients/BlockchainJsonRpcClient.ts
+++ b/src/api_clients/BlockchainJsonRpcClient.ts
@@ -9,14 +9,12 @@ function transformBlockchainResponse(
 ): DataOrErrors<BlockchainTransaction> {
   if (response.error) {
     return {
-      data: null,
       errors: [{ message: response.error.message }],
     }
   } else {
     return {
       // @ts-ignore (Tolerate a deficiency in library type)
       data: response.result[0],
-      errors: null,
     }
   }
 }
@@ -43,6 +41,6 @@ export async function getBlockchainTransaction(
       return transformBlockchainResponse(response)
     })
     .catch((error: FetchError) => {
-      return { errors: [{ message: error.toString() }], data: null }
+      return { errors: [{ message: error.toString() }] }
     })
 }

--- a/src/api_clients/BlockchainRestClient.test.ts
+++ b/src/api_clients/BlockchainRestClient.test.ts
@@ -176,7 +176,7 @@ const testPassesDataThrough = async (
   path: string,
   response: any
 ) => {
-  const expected = { data: response, errors: null }
+  const expected = { data: response }
   setBlockchainRestApiResponse(server, path, response)
   const result = await methodUnderTest(fakeAddress)
   expect(result).toEqual(expected)
@@ -186,7 +186,7 @@ const testPassesErrorsThrough = async (
   methodUnderTest: Function,
   path: string
 ) => {
-  const expected = { data: null, errors: [{ message: errorResponse.message }] }
+  const expected = { errors: [{ message: errorResponse.message }] }
   setBlockchainRestApiResponse(server, path, errorResponse)
   const result = await methodUnderTest(fakeAddress)
   expect(result).toEqual(expected)
@@ -198,7 +198,6 @@ const testNetworkErrorsAreErrors = async (
 ) => {
   const error = 'The internet went boom 💥'
   const expected = {
-    data: null,
     errors: [
       {
         message: `FetchError: request to ${

--- a/src/api_clients/BlockchainRestClient.test.ts
+++ b/src/api_clients/BlockchainRestClient.test.ts
@@ -227,7 +227,7 @@ describe('Blockchain REST Client', function () {
       await testNetworkErrorsAreErrors(getAccountResources, resourcesPath)
     })
     it('should canonicalize the address before calling the blockchain', async () => {
-      const expected = { data: goodResourceResponse, errors: null }
+      const expected = { data: goodResourceResponse }
       setBlockchainRestApiResponse(server, resourcesPath, goodResourceResponse)
       const result = await getAccountResources(nonCanonicalFakeAddress)
       expect(result).toEqual(expected)
@@ -236,7 +236,6 @@ describe('Blockchain REST Client', function () {
       setBlockchainRestApiResponse(server, resourcesPath, errorResponse)
       const result = await getAccountResources('this address is invalid')
       expect(result).toEqual({
-        data: null,
         errors: [
           {
             message:

--- a/src/api_clients/BlockchainRestClient.ts
+++ b/src/api_clients/BlockchainRestClient.ts
@@ -15,13 +15,11 @@ function transformBlockchainRestResponse<T extends Module[] | Resource[]>(
 ): DataOrErrors<T> {
   if ('message' in response && 'code' in response) {
     return {
-      data: null,
       errors: [{ message: response.message }],
     }
   } else {
     return {
       data: response as T,
-      errors: null,
     }
   }
 }
@@ -48,7 +46,6 @@ async function getAccountAsset<T extends Resource[] | Module[]>(
     .catch((error: FetchError) => {
       return {
         errors: [{ message: error.toString() }],
-        data: null,
       }
     })
 }

--- a/src/api_clients/BlockchainRestClient.ts
+++ b/src/api_clients/BlockchainRestClient.ts
@@ -34,7 +34,7 @@ async function getAccountAsset<T extends Resource[] | Module[]>(
 ): Promise<DataOrErrors<T>> {
   const canonicalAddress = getCanonicalAddress(address)
   if (canonicalAddress.err) {
-    return { data: null, errors: [{ message: canonicalAddress.val }] }
+    return { errors: [{ message: canonicalAddress.val }] }
   }
   const url = `${import.meta.env.VITE_BLOCKCHAIN_REST_URL}/accounts/${
     canonicalAddress.val

--- a/src/api_clients/FetchTypes.ts
+++ b/src/api_clients/FetchTypes.ts
@@ -8,7 +8,4 @@ export type FetchError = {
   type?: string
 }
 
-export type DataOrErrors<T, R = FetchError[]> = {
-  data: T | null
-  errors: R | null
-}
+export type DataOrErrors<T, R = FetchError[]> = { data: T } | { errors: R }

--- a/src/api_models/BlockchainTransaction.ts
+++ b/src/api_models/BlockchainTransaction.ts
@@ -1,5 +1,7 @@
 // Adapated from https://github.com/diem/diem/blob/master/json-rpc/docs/type_transaction.md#type-transactiondata
 
+import { KnownCurrency } from '../api_clients/BlockchainRestTypes'
+
 export interface TxnEvent {
   key: string
   sequence_number: number
@@ -26,7 +28,7 @@ export interface PeerToPeerWithMetadataBlockChainScript
   extends BlockchainScript {
   receiver: string
   amount: number
-  currency: string
+  currency: KnownCurrency
   metadata: string
   metadata_signature: string
 }

--- a/utils/Analytics_Hasura_Api_Zeus_Client/zeus/const.ts
+++ b/utils/Analytics_Hasura_Api_Zeus_Client/zeus/const.ts
@@ -229,6 +229,135 @@ export const AllTypesProps: Record<string,any> = {
 			required:false
 		}
 	},
+	account_roles_aggregate_fields:{
+		count:{
+			columns:{
+				type:"account_roles_select_column",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			distinct:{
+				type:"Boolean",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		}
+	},
+	account_roles_bool_exp:{
+		_and:{
+			type:"account_roles_bool_exp",
+			array:true,
+			arrayRequired:false,
+			required:true
+		},
+		_not:{
+			type:"account_roles_bool_exp",
+			array:false,
+			arrayRequired:false,
+			required:false
+		},
+		_or:{
+			type:"account_roles_bool_exp",
+			array:true,
+			arrayRequired:false,
+			required:true
+		},
+		id:{
+			type:"Int_comparison_exp",
+			array:false,
+			arrayRequired:false,
+			required:false
+		},
+		name:{
+			type:"String_comparison_exp",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_constraint: "enum",
+	account_roles_inc_input:{
+		id:{
+			type:"Int",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_insert_input:{
+		id:{
+			type:"Int",
+			array:false,
+			arrayRequired:false,
+			required:false
+		},
+		name:{
+			type:"String",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_on_conflict:{
+		constraint:{
+			type:"account_roles_constraint",
+			array:false,
+			arrayRequired:false,
+			required:true
+		},
+		update_columns:{
+			type:"account_roles_update_column",
+			array:true,
+			arrayRequired:true,
+			required:true
+		},
+		where:{
+			type:"account_roles_bool_exp",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_order_by:{
+		id:{
+			type:"order_by",
+			array:false,
+			arrayRequired:false,
+			required:false
+		},
+		name:{
+			type:"order_by",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_pk_columns_input:{
+		id:{
+			type:"Int",
+			array:false,
+			arrayRequired:false,
+			required:true
+		}
+	},
+	account_roles_select_column: "enum",
+	account_roles_set_input:{
+		id:{
+			type:"Int",
+			array:false,
+			arrayRequired:false,
+			required:false
+		},
+		name:{
+			type:"String",
+			array:false,
+			arrayRequired:false,
+			required:false
+		}
+	},
+	account_roles_update_column: "enum",
 	accounts_aggregate_fields:{
 		count:{
 			columns:{
@@ -1973,6 +2102,22 @@ export const AllTypesProps: Record<string,any> = {
 	},
 	gas_payments_update_column: "enum",
 	mutation_root:{
+		delete_account_roles:{
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
+		},
+		delete_account_roles_by_pk:{
+			id:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
+		},
 		delete_accounts:{
 			where:{
 				type:"accounts_bool_exp",
@@ -2185,6 +2330,34 @@ export const AllTypesProps: Record<string,any> = {
 				array:false,
 				arrayRequired:false,
 				required:true
+			}
+		},
+		insert_account_roles:{
+			objects:{
+				type:"account_roles_insert_input",
+				array:true,
+				arrayRequired:true,
+				required:true
+			},
+			on_conflict:{
+				type:"account_roles_on_conflict",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		},
+		insert_account_roles_one:{
+			object:{
+				type:"account_roles_insert_input",
+				array:false,
+				arrayRequired:false,
+				required:true
+			},
+			on_conflict:{
+				type:"account_roles_on_conflict",
+				array:false,
+				arrayRequired:false,
+				required:false
 			}
 		},
 		insert_accounts:{
@@ -2465,6 +2638,46 @@ export const AllTypesProps: Record<string,any> = {
 				array:false,
 				arrayRequired:false,
 				required:false
+			}
+		},
+		update_account_roles:{
+			_inc:{
+				type:"account_roles_inc_input",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			_set:{
+				type:"account_roles_set_input",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
+		},
+		update_account_roles_by_pk:{
+			_inc:{
+				type:"account_roles_inc_input",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			_set:{
+				type:"account_roles_set_input",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			pk_columns:{
+				type:"account_roles_pk_columns_input",
+				array:false,
+				arrayRequired:false,
+				required:true
 			}
 		},
 		update_accounts:{
@@ -3167,6 +3380,78 @@ export const AllTypesProps: Record<string,any> = {
 	},
 	preburn_events_update_column: "enum",
 	query_root:{
+		account_roles:{
+			distinct_on:{
+				type:"account_roles_select_column",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			limit:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			offset:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			order_by:{
+				type:"account_roles_order_by",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		},
+		account_roles_aggregate:{
+			distinct_on:{
+				type:"account_roles_select_column",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			limit:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			offset:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			order_by:{
+				type:"account_roles_order_by",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		},
+		account_roles_by_pk:{
+			id:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
+		},
 		accounts:{
 			distinct_on:{
 				type:"accounts_select_column",
@@ -4885,6 +5170,78 @@ export const AllTypesProps: Record<string,any> = {
 		}
 	},
 	subscription_root:{
+		account_roles:{
+			distinct_on:{
+				type:"account_roles_select_column",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			limit:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			offset:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			order_by:{
+				type:"account_roles_order_by",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		},
+		account_roles_aggregate:{
+			distinct_on:{
+				type:"account_roles_select_column",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			limit:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			offset:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:false
+			},
+			order_by:{
+				type:"account_roles_order_by",
+				array:true,
+				arrayRequired:false,
+				required:true
+			},
+			where:{
+				type:"account_roles_bool_exp",
+				array:false,
+				arrayRequired:false,
+				required:false
+			}
+		},
+		account_roles_by_pk:{
+			id:{
+				type:"Int",
+				array:false,
+				arrayRequired:false,
+				required:true
+			}
+		},
 		accounts:{
 			distinct_on:{
 				type:"accounts_select_column",
@@ -6159,6 +6516,63 @@ export const ReturnTypes: Record<string,any> = {
 		ttl:"Int",
 		refresh:"Boolean"
 	},
+	account_roles:{
+		id:"Int",
+		name:"String"
+	},
+	account_roles_aggregate:{
+		aggregate:"account_roles_aggregate_fields",
+		nodes:"account_roles"
+	},
+	account_roles_aggregate_fields:{
+		avg:"account_roles_avg_fields",
+		count:"Int",
+		max:"account_roles_max_fields",
+		min:"account_roles_min_fields",
+		stddev:"account_roles_stddev_fields",
+		stddev_pop:"account_roles_stddev_pop_fields",
+		stddev_samp:"account_roles_stddev_samp_fields",
+		sum:"account_roles_sum_fields",
+		var_pop:"account_roles_var_pop_fields",
+		var_samp:"account_roles_var_samp_fields",
+		variance:"account_roles_variance_fields"
+	},
+	account_roles_avg_fields:{
+		id:"Float"
+	},
+	account_roles_max_fields:{
+		id:"Int",
+		name:"String"
+	},
+	account_roles_min_fields:{
+		id:"Int",
+		name:"String"
+	},
+	account_roles_mutation_response:{
+		affected_rows:"Int",
+		returning:"account_roles"
+	},
+	account_roles_stddev_fields:{
+		id:"Float"
+	},
+	account_roles_stddev_pop_fields:{
+		id:"Float"
+	},
+	account_roles_stddev_samp_fields:{
+		id:"Float"
+	},
+	account_roles_sum_fields:{
+		id:"Int"
+	},
+	account_roles_var_pop_fields:{
+		id:"Float"
+	},
+	account_roles_var_samp_fields:{
+		id:"Float"
+	},
+	account_roles_variance_fields:{
+		id:"Float"
+	},
 	accounts:{
 		address:"bpchar",
 		authentication_key:"String",
@@ -6624,6 +7038,8 @@ export const ReturnTypes: Record<string,any> = {
 		version:"Float"
 	},
 	mutation_root:{
+		delete_account_roles:"account_roles_mutation_response",
+		delete_account_roles_by_pk:"account_roles",
 		delete_accounts:"accounts_mutation_response",
 		delete_accounts_balances:"accounts_balances_mutation_response",
 		delete_accounts_balances_by_pk:"accounts_balances",
@@ -6644,6 +7060,8 @@ export const ReturnTypes: Record<string,any> = {
 		delete_sentpayment_events_by_pk:"sentpayment_events",
 		delete_transactions:"transactions_mutation_response",
 		delete_transactions_by_pk:"transactions",
+		insert_account_roles:"account_roles_mutation_response",
+		insert_account_roles_one:"account_roles",
 		insert_accounts:"accounts_mutation_response",
 		insert_accounts_balances:"accounts_balances_mutation_response",
 		insert_accounts_balances_one:"accounts_balances",
@@ -6664,6 +7082,8 @@ export const ReturnTypes: Record<string,any> = {
 		insert_sentpayment_events_one:"sentpayment_events",
 		insert_transactions:"transactions_mutation_response",
 		insert_transactions_one:"transactions",
+		update_account_roles:"account_roles_mutation_response",
+		update_account_roles_by_pk:"account_roles",
 		update_accounts:"accounts_mutation_response",
 		update_accounts_balances:"accounts_balances_mutation_response",
 		update_accounts_balances_by_pk:"accounts_balances",
@@ -6785,6 +7205,9 @@ export const ReturnTypes: Record<string,any> = {
 		transaction_version:"Float"
 	},
 	query_root:{
+		account_roles:"account_roles",
+		account_roles_aggregate:"account_roles_aggregate",
+		account_roles_by_pk:"account_roles",
 		accounts:"accounts",
 		accounts_aggregate:"accounts_aggregate",
 		accounts_balances:"accounts_balances",
@@ -7098,6 +7521,9 @@ export const ReturnTypes: Record<string,any> = {
 		transaction_version:"Float"
 	},
 	subscription_root:{
+		account_roles:"account_roles",
+		account_roles_aggregate:"account_roles_aggregate",
+		account_roles_by_pk:"account_roles",
 		accounts:"accounts",
 		accounts_aggregate:"accounts_aggregate",
 		accounts_balances:"accounts_balances",

--- a/utils/Analytics_Hasura_Api_Zeus_Client/zeus/index.ts
+++ b/utils/Analytics_Hasura_Api_Zeus_Client/zeus/index.ts
@@ -61,6 +61,136 @@ export type ValueTypes = {
 	/** does the column match the given SQL regular expression */
 	_similar?:string | null
 };
+	/** columns and relationships of "account_roles" */
+["account_roles"]: AliasType<{
+	id?:true,
+	name?:true,
+		__typename?: true
+}>;
+	/** aggregated selection of "account_roles" */
+["account_roles_aggregate"]: AliasType<{
+	aggregate?:ValueTypes["account_roles_aggregate_fields"],
+	nodes?:ValueTypes["account_roles"],
+		__typename?: true
+}>;
+	/** aggregate fields of "account_roles" */
+["account_roles_aggregate_fields"]: AliasType<{
+	avg?:ValueTypes["account_roles_avg_fields"],
+count?: [{	columns?:ValueTypes["account_roles_select_column"][],	distinct?:boolean | null},true],
+	max?:ValueTypes["account_roles_max_fields"],
+	min?:ValueTypes["account_roles_min_fields"],
+	stddev?:ValueTypes["account_roles_stddev_fields"],
+	stddev_pop?:ValueTypes["account_roles_stddev_pop_fields"],
+	stddev_samp?:ValueTypes["account_roles_stddev_samp_fields"],
+	sum?:ValueTypes["account_roles_sum_fields"],
+	var_pop?:ValueTypes["account_roles_var_pop_fields"],
+	var_samp?:ValueTypes["account_roles_var_samp_fields"],
+	variance?:ValueTypes["account_roles_variance_fields"],
+		__typename?: true
+}>;
+	/** aggregate avg on columns */
+["account_roles_avg_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** Boolean expression to filter rows from the table "account_roles". All fields are combined with a logical 'AND'. */
+["account_roles_bool_exp"]: {
+	_and?:ValueTypes["account_roles_bool_exp"][],
+	_not?:ValueTypes["account_roles_bool_exp"] | null,
+	_or?:ValueTypes["account_roles_bool_exp"][],
+	id?:ValueTypes["Int_comparison_exp"] | null,
+	name?:ValueTypes["String_comparison_exp"] | null
+};
+	/** unique or primary key constraints on table "account_roles" */
+["account_roles_constraint"]:account_roles_constraint;
+	/** input type for incrementing numeric columns in table "account_roles" */
+["account_roles_inc_input"]: {
+	id?:number | null
+};
+	/** input type for inserting data into table "account_roles" */
+["account_roles_insert_input"]: {
+	id?:number | null,
+	name?:string | null
+};
+	/** aggregate max on columns */
+["account_roles_max_fields"]: AliasType<{
+	id?:true,
+	name?:true,
+		__typename?: true
+}>;
+	/** aggregate min on columns */
+["account_roles_min_fields"]: AliasType<{
+	id?:true,
+	name?:true,
+		__typename?: true
+}>;
+	/** response of any mutation on the table "account_roles" */
+["account_roles_mutation_response"]: AliasType<{
+	/** number of rows affected by the mutation */
+	affected_rows?:true,
+	/** data from the rows affected by the mutation */
+	returning?:ValueTypes["account_roles"],
+		__typename?: true
+}>;
+	/** on conflict condition type for table "account_roles" */
+["account_roles_on_conflict"]: {
+	constraint:ValueTypes["account_roles_constraint"],
+	update_columns:ValueTypes["account_roles_update_column"][],
+	where?:ValueTypes["account_roles_bool_exp"] | null
+};
+	/** Ordering options when selecting data from "account_roles". */
+["account_roles_order_by"]: {
+	id?:ValueTypes["order_by"] | null,
+	name?:ValueTypes["order_by"] | null
+};
+	/** primary key columns input for table: account_roles */
+["account_roles_pk_columns_input"]: {
+	id:number
+};
+	/** select columns of table "account_roles" */
+["account_roles_select_column"]:account_roles_select_column;
+	/** input type for updating data in table "account_roles" */
+["account_roles_set_input"]: {
+	id?:number | null,
+	name?:string | null
+};
+	/** aggregate stddev on columns */
+["account_roles_stddev_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** aggregate stddev_pop on columns */
+["account_roles_stddev_pop_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** aggregate stddev_samp on columns */
+["account_roles_stddev_samp_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** aggregate sum on columns */
+["account_roles_sum_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** update columns of table "account_roles" */
+["account_roles_update_column"]:account_roles_update_column;
+	/** aggregate var_pop on columns */
+["account_roles_var_pop_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** aggregate var_samp on columns */
+["account_roles_var_samp_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
+	/** aggregate variance on columns */
+["account_roles_variance_fields"]: AliasType<{
+	id?:true,
+		__typename?: true
+}>;
 	/** columns and relationships of "accounts" */
 ["accounts"]: AliasType<{
 	address?:true,
@@ -1092,6 +1222,9 @@ count?: [{	columns?:ValueTypes["gas_payments_select_column"][],	distinct?:boolea
 }>;
 	/** mutation root */
 ["mutation_root"]: AliasType<{
+delete_account_roles?: [{	/** filter the rows which have to be deleted */
+	where:ValueTypes["account_roles_bool_exp"]},ValueTypes["account_roles_mutation_response"]],
+delete_account_roles_by_pk?: [{	id:number},ValueTypes["account_roles"]],
 delete_accounts?: [{	/** filter the rows which have to be deleted */
 	where:ValueTypes["accounts_bool_exp"]},ValueTypes["accounts_mutation_response"]],
 delete_accounts_balances?: [{	/** filter the rows which have to be deleted */
@@ -1122,6 +1255,12 @@ delete_sentpayment_events_by_pk?: [{	key:string,	sequence_number:ValueTypes["big
 delete_transactions?: [{	/** filter the rows which have to be deleted */
 	where:ValueTypes["transactions_bool_exp"]},ValueTypes["transactions_mutation_response"]],
 delete_transactions_by_pk?: [{	version:ValueTypes["bigint"]},ValueTypes["transactions"]],
+insert_account_roles?: [{	/** the rows to be inserted */
+	objects:ValueTypes["account_roles_insert_input"][],	/** on conflict condition */
+	on_conflict?:ValueTypes["account_roles_on_conflict"] | null},ValueTypes["account_roles_mutation_response"]],
+insert_account_roles_one?: [{	/** the row to be inserted */
+	object:ValueTypes["account_roles_insert_input"],	/** on conflict condition */
+	on_conflict?:ValueTypes["account_roles_on_conflict"] | null},ValueTypes["account_roles"]],
 insert_accounts?: [{	/** the rows to be inserted */
 	objects:ValueTypes["accounts_insert_input"][],	/** on conflict condition */
 	on_conflict?:ValueTypes["accounts_on_conflict"] | null},ValueTypes["accounts_mutation_response"]],
@@ -1182,6 +1321,13 @@ insert_transactions?: [{	/** the rows to be inserted */
 insert_transactions_one?: [{	/** the row to be inserted */
 	object:ValueTypes["transactions_insert_input"],	/** on conflict condition */
 	on_conflict?:ValueTypes["transactions_on_conflict"] | null},ValueTypes["transactions"]],
+update_account_roles?: [{	/** increments the numeric columns with given value of the filtered values */
+	_inc?:ValueTypes["account_roles_inc_input"] | null,	/** sets the columns of the filtered rows to the given values */
+	_set?:ValueTypes["account_roles_set_input"] | null,	/** filter the rows which have to be updated */
+	where:ValueTypes["account_roles_bool_exp"]},ValueTypes["account_roles_mutation_response"]],
+update_account_roles_by_pk?: [{	/** increments the numeric columns with given value of the filtered values */
+	_inc?:ValueTypes["account_roles_inc_input"] | null,	/** sets the columns of the filtered rows to the given values */
+	_set?:ValueTypes["account_roles_set_input"] | null,	pk_columns:ValueTypes["account_roles_pk_columns_input"]},ValueTypes["account_roles"]],
 update_accounts?: [{	/** increments the numeric columns with given value of the filtered values */
 	_inc?:ValueTypes["accounts_inc_input"] | null,	/** sets the columns of the filtered rows to the given values */
 	_set?:ValueTypes["accounts_set_input"] | null,	/** filter the rows which have to be updated */
@@ -1457,6 +1603,19 @@ count?: [{	columns?:ValueTypes["preburn_events_select_column"][],	distinct?:bool
 		__typename?: true
 }>;
 	["query_root"]: AliasType<{
+account_roles?: [{	/** distinct select on columns */
+	distinct_on?:ValueTypes["account_roles_select_column"][],	/** limit the number of rows returned */
+	limit?:number | null,	/** skip the first n rows. Use only with order_by */
+	offset?:number | null,	/** sort the rows by one or more columns */
+	order_by?:ValueTypes["account_roles_order_by"][],	/** filter the rows returned */
+	where?:ValueTypes["account_roles_bool_exp"] | null},ValueTypes["account_roles"]],
+account_roles_aggregate?: [{	/** distinct select on columns */
+	distinct_on?:ValueTypes["account_roles_select_column"][],	/** limit the number of rows returned */
+	limit?:number | null,	/** skip the first n rows. Use only with order_by */
+	offset?:number | null,	/** sort the rows by one or more columns */
+	order_by?:ValueTypes["account_roles_order_by"][],	/** filter the rows returned */
+	where?:ValueTypes["account_roles_bool_exp"] | null},ValueTypes["account_roles_aggregate"]],
+account_roles_by_pk?: [{	id:number},ValueTypes["account_roles"]],
 accounts?: [{	/** distinct select on columns */
 	distinct_on?:ValueTypes["accounts_select_column"][],	/** limit the number of rows returned */
 	limit?:number | null,	/** skip the first n rows. Use only with order_by */
@@ -2186,6 +2345,19 @@ count?: [{	columns?:ValueTypes["sentpayment_events_select_column"][],	distinct?:
 	_nin?:ValueTypes["smallint"][]
 };
 	["subscription_root"]: AliasType<{
+account_roles?: [{	/** distinct select on columns */
+	distinct_on?:ValueTypes["account_roles_select_column"][],	/** limit the number of rows returned */
+	limit?:number | null,	/** skip the first n rows. Use only with order_by */
+	offset?:number | null,	/** sort the rows by one or more columns */
+	order_by?:ValueTypes["account_roles_order_by"][],	/** filter the rows returned */
+	where?:ValueTypes["account_roles_bool_exp"] | null},ValueTypes["account_roles"]],
+account_roles_aggregate?: [{	/** distinct select on columns */
+	distinct_on?:ValueTypes["account_roles_select_column"][],	/** limit the number of rows returned */
+	limit?:number | null,	/** skip the first n rows. Use only with order_by */
+	offset?:number | null,	/** sort the rows by one or more columns */
+	order_by?:ValueTypes["account_roles_order_by"][],	/** filter the rows returned */
+	where?:ValueTypes["account_roles_bool_exp"] | null},ValueTypes["account_roles_aggregate"]],
+account_roles_by_pk?: [{	id:number},ValueTypes["account_roles"]],
 accounts?: [{	/** distinct select on columns */
 	distinct_on?:ValueTypes["accounts_select_column"][],	/** limit the number of rows returned */
 	limit?:number | null,	/** skip the first n rows. Use only with order_by */
@@ -2610,6 +2782,99 @@ export type ModelTypes = {
 ["Int_comparison_exp"]: GraphQLTypes["Int_comparison_exp"];
 	/** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 ["String_comparison_exp"]: GraphQLTypes["String_comparison_exp"];
+	/** columns and relationships of "account_roles" */
+["account_roles"]: {
+		id:number,
+	name:string
+};
+	/** aggregated selection of "account_roles" */
+["account_roles_aggregate"]: {
+		aggregate?:ModelTypes["account_roles_aggregate_fields"],
+	nodes:ModelTypes["account_roles"][]
+};
+	/** aggregate fields of "account_roles" */
+["account_roles_aggregate_fields"]: {
+		avg?:ModelTypes["account_roles_avg_fields"],
+	count:number,
+	max?:ModelTypes["account_roles_max_fields"],
+	min?:ModelTypes["account_roles_min_fields"],
+	stddev?:ModelTypes["account_roles_stddev_fields"],
+	stddev_pop?:ModelTypes["account_roles_stddev_pop_fields"],
+	stddev_samp?:ModelTypes["account_roles_stddev_samp_fields"],
+	sum?:ModelTypes["account_roles_sum_fields"],
+	var_pop?:ModelTypes["account_roles_var_pop_fields"],
+	var_samp?:ModelTypes["account_roles_var_samp_fields"],
+	variance?:ModelTypes["account_roles_variance_fields"]
+};
+	/** aggregate avg on columns */
+["account_roles_avg_fields"]: {
+		id?:number
+};
+	/** Boolean expression to filter rows from the table "account_roles". All fields are combined with a logical 'AND'. */
+["account_roles_bool_exp"]: GraphQLTypes["account_roles_bool_exp"];
+	/** unique or primary key constraints on table "account_roles" */
+["account_roles_constraint"]: GraphQLTypes["account_roles_constraint"];
+	/** input type for incrementing numeric columns in table "account_roles" */
+["account_roles_inc_input"]: GraphQLTypes["account_roles_inc_input"];
+	/** input type for inserting data into table "account_roles" */
+["account_roles_insert_input"]: GraphQLTypes["account_roles_insert_input"];
+	/** aggregate max on columns */
+["account_roles_max_fields"]: {
+		id?:number,
+	name?:string
+};
+	/** aggregate min on columns */
+["account_roles_min_fields"]: {
+		id?:number,
+	name?:string
+};
+	/** response of any mutation on the table "account_roles" */
+["account_roles_mutation_response"]: {
+		/** number of rows affected by the mutation */
+	affected_rows:number,
+	/** data from the rows affected by the mutation */
+	returning:ModelTypes["account_roles"][]
+};
+	/** on conflict condition type for table "account_roles" */
+["account_roles_on_conflict"]: GraphQLTypes["account_roles_on_conflict"];
+	/** Ordering options when selecting data from "account_roles". */
+["account_roles_order_by"]: GraphQLTypes["account_roles_order_by"];
+	/** primary key columns input for table: account_roles */
+["account_roles_pk_columns_input"]: GraphQLTypes["account_roles_pk_columns_input"];
+	/** select columns of table "account_roles" */
+["account_roles_select_column"]: GraphQLTypes["account_roles_select_column"];
+	/** input type for updating data in table "account_roles" */
+["account_roles_set_input"]: GraphQLTypes["account_roles_set_input"];
+	/** aggregate stddev on columns */
+["account_roles_stddev_fields"]: {
+		id?:number
+};
+	/** aggregate stddev_pop on columns */
+["account_roles_stddev_pop_fields"]: {
+		id?:number
+};
+	/** aggregate stddev_samp on columns */
+["account_roles_stddev_samp_fields"]: {
+		id?:number
+};
+	/** aggregate sum on columns */
+["account_roles_sum_fields"]: {
+		id?:number
+};
+	/** update columns of table "account_roles" */
+["account_roles_update_column"]: GraphQLTypes["account_roles_update_column"];
+	/** aggregate var_pop on columns */
+["account_roles_var_pop_fields"]: {
+		id?:number
+};
+	/** aggregate var_samp on columns */
+["account_roles_var_samp_fields"]: {
+		id?:number
+};
+	/** aggregate variance on columns */
+["account_roles_variance_fields"]: {
+		id?:number
+};
 	/** columns and relationships of "accounts" */
 ["accounts"]: {
 		address:ModelTypes["bpchar"],
@@ -3262,7 +3527,11 @@ export type ModelTypes = {
 };
 	/** mutation root */
 ["mutation_root"]: {
-		/** delete data from the table: "accounts" */
+		/** delete data from the table: "account_roles" */
+	delete_account_roles?:ModelTypes["account_roles_mutation_response"],
+	/** delete single row from the table: "account_roles" */
+	delete_account_roles_by_pk?:ModelTypes["account_roles"],
+	/** delete data from the table: "accounts" */
 	delete_accounts?:ModelTypes["accounts_mutation_response"],
 	/** delete data from the table: "accounts_balances" */
 	delete_accounts_balances?:ModelTypes["accounts_balances_mutation_response"],
@@ -3302,6 +3571,10 @@ export type ModelTypes = {
 	delete_transactions?:ModelTypes["transactions_mutation_response"],
 	/** delete single row from the table: "transactions" */
 	delete_transactions_by_pk?:ModelTypes["transactions"],
+	/** insert data into the table: "account_roles" */
+	insert_account_roles?:ModelTypes["account_roles_mutation_response"],
+	/** insert a single row into the table: "account_roles" */
+	insert_account_roles_one?:ModelTypes["account_roles"],
 	/** insert data into the table: "accounts" */
 	insert_accounts?:ModelTypes["accounts_mutation_response"],
 	/** insert data into the table: "accounts_balances" */
@@ -3342,6 +3615,10 @@ export type ModelTypes = {
 	insert_transactions?:ModelTypes["transactions_mutation_response"],
 	/** insert a single row into the table: "transactions" */
 	insert_transactions_one?:ModelTypes["transactions"],
+	/** update data of the table: "account_roles" */
+	update_account_roles?:ModelTypes["account_roles_mutation_response"],
+	/** update single row of the table: "account_roles" */
+	update_account_roles_by_pk?:ModelTypes["account_roles"],
 	/** update data of the table: "accounts" */
 	update_accounts?:ModelTypes["accounts_mutation_response"],
 	/** update data of the table: "accounts_balances" */
@@ -3521,7 +3798,13 @@ export type ModelTypes = {
 	transaction_version?:number
 };
 	["query_root"]: {
-		/** fetch data from the table: "accounts" */
+		/** fetch data from the table: "account_roles" */
+	account_roles:ModelTypes["account_roles"][],
+	/** fetch aggregated fields from the table: "account_roles" */
+	account_roles_aggregate:ModelTypes["account_roles_aggregate"],
+	/** fetch data from the table: "account_roles" using primary key columns */
+	account_roles_by_pk?:ModelTypes["account_roles"],
+	/** fetch data from the table: "accounts" */
 	accounts:ModelTypes["accounts"][],
 	/** fetch aggregated fields from the table: "accounts" */
 	accounts_aggregate:ModelTypes["accounts_aggregate"],
@@ -3975,7 +4258,13 @@ export type ModelTypes = {
 	/** Boolean expression to compare columns of type "smallint". All fields are combined with logical 'AND'. */
 ["smallint_comparison_exp"]: GraphQLTypes["smallint_comparison_exp"];
 	["subscription_root"]: {
-		/** fetch data from the table: "accounts" */
+		/** fetch data from the table: "account_roles" */
+	account_roles:ModelTypes["account_roles"][],
+	/** fetch aggregated fields from the table: "account_roles" */
+	account_roles_aggregate:ModelTypes["account_roles_aggregate"],
+	/** fetch data from the table: "account_roles" using primary key columns */
+	account_roles_by_pk?:ModelTypes["account_roles"],
+	/** fetch data from the table: "accounts" */
 	accounts:ModelTypes["accounts"][],
 	/** fetch aggregated fields from the table: "accounts" */
 	accounts_aggregate:ModelTypes["accounts_aggregate"],
@@ -4279,6 +4568,136 @@ export type GraphQLTypes = {
 	_regex?: string,
 	/** does the column match the given SQL regular expression */
 	_similar?: string
+};
+	/** columns and relationships of "account_roles" */
+["account_roles"]: {
+	__typename: "account_roles",
+	id: number,
+	name: string
+};
+	/** aggregated selection of "account_roles" */
+["account_roles_aggregate"]: {
+	__typename: "account_roles_aggregate",
+	aggregate?: GraphQLTypes["account_roles_aggregate_fields"],
+	nodes: Array<GraphQLTypes["account_roles"]>
+};
+	/** aggregate fields of "account_roles" */
+["account_roles_aggregate_fields"]: {
+	__typename: "account_roles_aggregate_fields",
+	avg?: GraphQLTypes["account_roles_avg_fields"],
+	count: number,
+	max?: GraphQLTypes["account_roles_max_fields"],
+	min?: GraphQLTypes["account_roles_min_fields"],
+	stddev?: GraphQLTypes["account_roles_stddev_fields"],
+	stddev_pop?: GraphQLTypes["account_roles_stddev_pop_fields"],
+	stddev_samp?: GraphQLTypes["account_roles_stddev_samp_fields"],
+	sum?: GraphQLTypes["account_roles_sum_fields"],
+	var_pop?: GraphQLTypes["account_roles_var_pop_fields"],
+	var_samp?: GraphQLTypes["account_roles_var_samp_fields"],
+	variance?: GraphQLTypes["account_roles_variance_fields"]
+};
+	/** aggregate avg on columns */
+["account_roles_avg_fields"]: {
+	__typename: "account_roles_avg_fields",
+	id?: number
+};
+	/** Boolean expression to filter rows from the table "account_roles". All fields are combined with a logical 'AND'. */
+["account_roles_bool_exp"]: {
+		_and?: Array<GraphQLTypes["account_roles_bool_exp"]>,
+	_not?: GraphQLTypes["account_roles_bool_exp"],
+	_or?: Array<GraphQLTypes["account_roles_bool_exp"]>,
+	id?: GraphQLTypes["Int_comparison_exp"],
+	name?: GraphQLTypes["String_comparison_exp"]
+};
+	/** unique or primary key constraints on table "account_roles" */
+["account_roles_constraint"]: account_roles_constraint;
+	/** input type for incrementing numeric columns in table "account_roles" */
+["account_roles_inc_input"]: {
+		id?: number
+};
+	/** input type for inserting data into table "account_roles" */
+["account_roles_insert_input"]: {
+		id?: number,
+	name?: string
+};
+	/** aggregate max on columns */
+["account_roles_max_fields"]: {
+	__typename: "account_roles_max_fields",
+	id?: number,
+	name?: string
+};
+	/** aggregate min on columns */
+["account_roles_min_fields"]: {
+	__typename: "account_roles_min_fields",
+	id?: number,
+	name?: string
+};
+	/** response of any mutation on the table "account_roles" */
+["account_roles_mutation_response"]: {
+	__typename: "account_roles_mutation_response",
+	/** number of rows affected by the mutation */
+	affected_rows: number,
+	/** data from the rows affected by the mutation */
+	returning: Array<GraphQLTypes["account_roles"]>
+};
+	/** on conflict condition type for table "account_roles" */
+["account_roles_on_conflict"]: {
+		constraint: GraphQLTypes["account_roles_constraint"],
+	update_columns: Array<GraphQLTypes["account_roles_update_column"]>,
+	where?: GraphQLTypes["account_roles_bool_exp"]
+};
+	/** Ordering options when selecting data from "account_roles". */
+["account_roles_order_by"]: {
+		id?: GraphQLTypes["order_by"],
+	name?: GraphQLTypes["order_by"]
+};
+	/** primary key columns input for table: account_roles */
+["account_roles_pk_columns_input"]: {
+		id: number
+};
+	/** select columns of table "account_roles" */
+["account_roles_select_column"]: account_roles_select_column;
+	/** input type for updating data in table "account_roles" */
+["account_roles_set_input"]: {
+		id?: number,
+	name?: string
+};
+	/** aggregate stddev on columns */
+["account_roles_stddev_fields"]: {
+	__typename: "account_roles_stddev_fields",
+	id?: number
+};
+	/** aggregate stddev_pop on columns */
+["account_roles_stddev_pop_fields"]: {
+	__typename: "account_roles_stddev_pop_fields",
+	id?: number
+};
+	/** aggregate stddev_samp on columns */
+["account_roles_stddev_samp_fields"]: {
+	__typename: "account_roles_stddev_samp_fields",
+	id?: number
+};
+	/** aggregate sum on columns */
+["account_roles_sum_fields"]: {
+	__typename: "account_roles_sum_fields",
+	id?: number
+};
+	/** update columns of table "account_roles" */
+["account_roles_update_column"]: account_roles_update_column;
+	/** aggregate var_pop on columns */
+["account_roles_var_pop_fields"]: {
+	__typename: "account_roles_var_pop_fields",
+	id?: number
+};
+	/** aggregate var_samp on columns */
+["account_roles_var_samp_fields"]: {
+	__typename: "account_roles_var_samp_fields",
+	id?: number
+};
+	/** aggregate variance on columns */
+["account_roles_variance_fields"]: {
+	__typename: "account_roles_variance_fields",
+	id?: number
 };
 	/** columns and relationships of "accounts" */
 ["accounts"]: {
@@ -5312,6 +5731,10 @@ export type GraphQLTypes = {
 	/** mutation root */
 ["mutation_root"]: {
 	__typename: "mutation_root",
+	/** delete data from the table: "account_roles" */
+	delete_account_roles?: GraphQLTypes["account_roles_mutation_response"],
+	/** delete single row from the table: "account_roles" */
+	delete_account_roles_by_pk?: GraphQLTypes["account_roles"],
 	/** delete data from the table: "accounts" */
 	delete_accounts?: GraphQLTypes["accounts_mutation_response"],
 	/** delete data from the table: "accounts_balances" */
@@ -5352,6 +5775,10 @@ export type GraphQLTypes = {
 	delete_transactions?: GraphQLTypes["transactions_mutation_response"],
 	/** delete single row from the table: "transactions" */
 	delete_transactions_by_pk?: GraphQLTypes["transactions"],
+	/** insert data into the table: "account_roles" */
+	insert_account_roles?: GraphQLTypes["account_roles_mutation_response"],
+	/** insert a single row into the table: "account_roles" */
+	insert_account_roles_one?: GraphQLTypes["account_roles"],
 	/** insert data into the table: "accounts" */
 	insert_accounts?: GraphQLTypes["accounts_mutation_response"],
 	/** insert data into the table: "accounts_balances" */
@@ -5392,6 +5819,10 @@ export type GraphQLTypes = {
 	insert_transactions?: GraphQLTypes["transactions_mutation_response"],
 	/** insert a single row into the table: "transactions" */
 	insert_transactions_one?: GraphQLTypes["transactions"],
+	/** update data of the table: "account_roles" */
+	update_account_roles?: GraphQLTypes["account_roles_mutation_response"],
+	/** update single row of the table: "account_roles" */
+	update_account_roles_by_pk?: GraphQLTypes["account_roles"],
 	/** update data of the table: "accounts" */
 	update_accounts?: GraphQLTypes["accounts_mutation_response"],
 	/** update data of the table: "accounts_balances" */
@@ -5637,6 +6068,12 @@ export type GraphQLTypes = {
 };
 	["query_root"]: {
 	__typename: "query_root",
+	/** fetch data from the table: "account_roles" */
+	account_roles: Array<GraphQLTypes["account_roles"]>,
+	/** fetch aggregated fields from the table: "account_roles" */
+	account_roles_aggregate: GraphQLTypes["account_roles_aggregate"],
+	/** fetch data from the table: "account_roles" using primary key columns */
+	account_roles_by_pk?: GraphQLTypes["account_roles"],
 	/** fetch data from the table: "accounts" */
 	accounts: Array<GraphQLTypes["accounts"]>,
 	/** fetch aggregated fields from the table: "accounts" */
@@ -6296,6 +6733,12 @@ export type GraphQLTypes = {
 };
 	["subscription_root"]: {
 	__typename: "subscription_root",
+	/** fetch data from the table: "account_roles" */
+	account_roles: Array<GraphQLTypes["account_roles"]>,
+	/** fetch aggregated fields from the table: "account_roles" */
+	account_roles_aggregate: GraphQLTypes["account_roles_aggregate"],
+	/** fetch data from the table: "account_roles" using primary key columns */
+	account_roles_by_pk?: GraphQLTypes["account_roles"],
 	/** fetch data from the table: "accounts" */
 	accounts: Array<GraphQLTypes["accounts"]>,
 	/** fetch aggregated fields from the table: "accounts" */
@@ -6641,6 +7084,20 @@ export type GraphQLTypes = {
 	version?: number
 }
     }
+/** unique or primary key constraints on table "account_roles" */
+export const enum account_roles_constraint {
+	account_roles_pkey = "account_roles_pkey"
+}
+/** select columns of table "account_roles" */
+export const enum account_roles_select_column {
+	id = "id",
+	name = "name"
+}
+/** update columns of table "account_roles" */
+export const enum account_roles_update_column {
+	id = "id",
+	name = "name"
+}
 /** unique or primary key constraints on table "accounts_balances" */
 export const enum accounts_balances_constraint {
 	accounts_balances_pkey = "accounts_balances_pkey"


### PR DESCRIPTION
Finishes #56.

This includes:
- Add Leaderboard page
- Display top 10 XUS transactions in the past 24 hours in a card on the leaderboard page
- Establish patterns for cards that load individually
- Various type safety improvements