### PR TITLE
Remove config.json from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY package.json /app
 COPY yarn.lock /app
 RUN yarn install
 COPY . /app
-RUN jq 'to_entries | map_values({ (.key) : ("$" + .key) }) | reduce .[] as $item ({}; . + $item)' ./src/config.json > ./src/config.tmp.json && mv ./src/config.tmp.json ./src/config.json
 RUN yarn run -- vite build
 
 FROM nginx:1.21


### PR DESCRIPTION
We removed config.json as part of deprecating the Blockchain JSON RPC integration but forgot to remove references to the file from our Dockerfile. 

This pr removes it.