### PR TITLE
Replace DataOrErrors with Result

### DIFF
--- a/src/ApiRequestComponent.test.tsx
+++ b/src/ApiRequestComponent.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from '@testing-library/react'
 import ApiRequestComponent from './ApiRequestComponent'
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
+import { Err, Ok } from 'ts-results'
 
 const childComponentText = 'The data loaded and it was this: '
 const childComponentRole = 'main'
@@ -93,7 +94,7 @@ describe('ApiRequestComponent', () => {
     })
     it('should render children with data if no errors', async () => {
       act(() => {
-        resolveApiPromise({ data })
+        resolveApiPromise(Ok(data))
       })
 
       await waitFor(() => screen.getByRole(childComponentRole))
@@ -109,7 +110,7 @@ describe('ApiRequestComponent', () => {
 
     it('should render errorComponent with errors if there are errors', async () => {
       act(() => {
-        resolveApiPromise({ errors: [error] })
+        resolveApiPromise(Err([error]))
       })
 
       await waitFor(() => screen.getByRole(errorComponentRole))

--- a/src/ApiRequestComponent.tsx
+++ b/src/ApiRequestComponent.tsx
@@ -1,15 +1,16 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import MainWrapper from './MainWrapper'
-import { DataOrErrors } from './api_clients/FetchTypes'
 import { Card } from 'react-bootstrap'
 import Loadable, { LoadingState } from './Loadable'
+import { Result } from 'ts-results'
+import { ResponseError } from './api_clients/FetchBroker'
 
-interface ApiRequestPageProps<T> {
-  children: ReactElement
-  request: (...args: any[]) => Promise<DataOrErrors<T>>
+interface ApiRequestComponentProps<T, E> {
+  children: ReactElement<{ data: T }>
+  request: (...args: any[]) => Promise<Result<T, E>>
   args?: any[]
   loadingComponent?: ReactElement
-  errorComponent?: ReactElement
+  errorComponent?: ReactElement<{ errors?: E }>
 }
 
 export function PlainValue<T>({ data }: { data?: T }) {
@@ -64,22 +65,20 @@ export const LoadingCardComponent = ({ title = '' }: { title?: string }) => (
 
 const DefaultLoadingComponent = FullPageLoadingComponent
 
-function ApiRequestComponent<T>({
+function ApiRequestComponent<T, E = ResponseError>({
   request,
   args = [],
   children,
   loadingComponent = <DefaultLoadingComponent />,
   errorComponent = <DefaultErrorComponent />,
-}: ApiRequestPageProps<T>) {
-  const [loadingState, setLoadingState] = useState<LoadingState<T>>({
+}: ApiRequestComponentProps<T, E>) {
+  const [loadingState, setLoadingState] = useState<LoadingState<T, E>>({
     isLoading: true,
   })
 
   useEffect(() => {
     async function getResponse() {
-      await request(...args).then((apiResponse) => {
-        setLoadingState(apiResponse)
-      })
+      await request(...args).then((apiResponse) => setLoadingState(apiResponse))
     }
 
     getResponse()

--- a/src/Loadable.tsx
+++ b/src/Loadable.tsx
@@ -1,30 +1,30 @@
-import { DataOrErrors } from './api_clients/FetchTypes'
 import React, { ReactElement } from 'react'
 import { ReactJSXElement } from '@emotion/react/types/jsx-namespace'
 import {
   PlainErrorComponent,
   PlainLoadingComponent,
 } from './ApiRequestComponent'
+import { Result } from 'ts-results'
 
-export type LoadingState<T> = DataOrErrors<T> | { isLoading: true }
+export type LoadingState<T, E> = Result<T, E> | { isLoading: true }
 
-type LoadableProps<T> = {
-  state: LoadingState<T>
-  children: ReactElement
+type LoadableProps<T, E> = {
+  state: LoadingState<T, E>
+  children: ReactElement<{ data: T }>
   loadingComponent?: ReactElement
-  errorComponent?: ReactElement
+  errorComponent?: ReactElement<{ errors?: E }>
 }
 
-export default function Loadable<T>({
+export default function Loadable<T, E>({
   state,
   loadingComponent = <PlainLoadingComponent />,
   errorComponent = <PlainErrorComponent />,
   children,
-}: LoadableProps<T>): ReactJSXElement {
+}: LoadableProps<T, E>): ReactJSXElement {
   if (!state) return errorComponent
   else if ('isLoading' in state) return loadingComponent
-  else if ('errors' in state)
-    return React.cloneElement(errorComponent, { errors: state.errors })
-  else if (children) return React.cloneElement(children, { data: state.data })
-  return errorComponent
+  else if (state.err)
+    return React.cloneElement(errorComponent, { errors: state.val })
+  else if (children) return React.cloneElement(children, { data: state.val })
+  else return errorComponent
 }

--- a/src/Pages/DiemInCirculationPage/DiemInCirculationPage.test.tsx
+++ b/src/Pages/DiemInCirculationPage/DiemInCirculationPage.test.tsx
@@ -14,6 +14,7 @@ import {
   DiemInCirculationHistoryType,
 } from '../../api_clients/AnalyticsQueries'
 import moment from 'moment'
+import { Ok } from 'ts-results'
 
 jest.useFakeTimers().setSystemTime(new Date('2021-11-01').getTime())
 
@@ -54,9 +55,9 @@ const renderSubject = async (
 ) => {
   postQueryToAnalyticsApi
     // @ts-ignore TS is bad at mocking
-    .mockResolvedValueOnce({ data: xusInCirculationResponse })
-    .mockResolvedValueOnce({ data: xdxInCirculationResponse })
-    .mockResolvedValueOnce({ data: historyResponse })
+    .mockResolvedValueOnce(Ok(xusInCirculationResponse))
+    .mockResolvedValueOnce(Ok(xdxInCirculationResponse))
+    .mockResolvedValueOnce(Ok(historyResponse))
   render(
     <BrowserRouter>
       <DiemInCirculationPage />

--- a/src/Pages/EventPages/EventPage.test.tsx
+++ b/src/Pages/EventPages/EventPage.test.tsx
@@ -9,6 +9,7 @@ import {
 import { BrowserRouter } from 'react-router-dom'
 import { TruncatedCell } from '../../TableComponents/TruncatedCell'
 import EventPage from './EventPage'
+import { Ok } from 'ts-results'
 
 jest.mock('../../api_clients/AnalyticsClient', () => ({
   ...jest.requireActual('../../api_clients/AnalyticsClient'),
@@ -39,9 +40,8 @@ const eventType = 'Arbitrary'
 
 beforeEach(async () => {
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValue({
-    data: [mockFakeEvent],
-  })
+  postQueryToAnalyticsApi.mockResolvedValue(Ok([mockFakeEvent]))
+
   render(
     <BrowserRouter>
       <EventPage
@@ -52,6 +52,7 @@ beforeEach(async () => {
       />
     </BrowserRouter>
   )
+
   await waitForElementToBeRemoved(screen.queryByRole('loading'))
 })
 

--- a/src/Pages/LandingPage/LandingPage.test.tsx
+++ b/src/Pages/LandingPage/LandingPage.test.tsx
@@ -16,6 +16,7 @@ import {
   TransactionsQueryType,
 } from '../../api_clients/AnalyticsQueries'
 import userEvent from '@testing-library/user-event'
+import { Ok } from 'ts-results'
 
 jest.useFakeTimers().setSystemTime(new Date('2021-01-01').getTime())
 
@@ -56,31 +57,34 @@ const renderSubject = async (
   countTxnsInLast10m: number = 42 * 600
 ) => {
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValueOnce({
-    data: { aggregate: { count: countTxnsInLast10m } },
-  })
+  postQueryToAnalyticsApi.mockResolvedValueOnce(
+    Ok({
+      aggregate: { count: countTxnsInLast10m },
+    })
+  )
+
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValueOnce({
-    data: transactions,
-  })
+  postQueryToAnalyticsApi.mockResolvedValueOnce(Ok(transactions))
+
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValueOnce({
-    data: [
+  postQueryToAnalyticsApi.mockResolvedValueOnce(
+    Ok([
       {
         total_burn_value: 700,
         total_mint_value: 800,
         total_net_value: 100,
       },
-    ],
-  })
+    ])
+  )
+
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValueOnce({
-    data: {
+  postQueryToAnalyticsApi.mockResolvedValueOnce(
+    Ok({
       aggregate: {
         count: 123,
       },
-    },
-  })
+    })
+  )
 
   render(
     <BrowserRouter>

--- a/src/Pages/LeaderboardPage/Cards/Top10AccountsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10AccountsCard.test.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10AccountsQuery } from '../../../api_clients/AnalyticsQueries'
 import Top10AccountsCard, { TopAccountEvent } from './Top10AccountsCard'
+import { Ok } from 'ts-results'
 
 jest.useFakeTimers().setSystemTime(new Date('2021-01-01').getTime())
 
@@ -17,9 +18,7 @@ jest.mock('../../../api_clients/AnalyticsClient', () => ({
 
 const renderSubject = async (accounts: TopAccountEvent[] = []) => {
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValue({
-    data: accounts,
-  })
+  postQueryToAnalyticsApi.mockResolvedValue(Ok(accounts))
 
   render(
     <BrowserRouter>

--- a/src/Pages/LeaderboardPage/Cards/Top10AccountsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10AccountsCard.tsx
@@ -2,7 +2,6 @@ import ApiRequestComponent, {
   ErrorCardComponent,
   LoadingCardComponent,
 } from '../../../ApiRequestComponent'
-import { DataOrErrors } from '../../../api_clients/FetchTypes'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import {
   AccountBalancesQueryType,
@@ -13,6 +12,8 @@ import { Card } from 'react-bootstrap'
 import Table, { column } from '../../../Table'
 import ReactTooltip from 'react-tooltip'
 import { AccountAddress } from '../../../TableComponents/Link'
+import { Ok, Result } from 'ts-results'
+import { FetchError } from '../../../api_clients/FetchTypes'
 
 export interface TopAccountEvent {
   address: string
@@ -54,17 +55,13 @@ function Top10AccountsTable({ data }: { data: Top10AccountsTableProps }) {
 
 async function getTopAccounts(
   currency: KnownCurrency
-): Promise<DataOrErrors<Top10AccountsTableProps>> {
-  const result: DataOrErrors<TopAccountEvent[]> =
+): Promise<Result<Top10AccountsTableProps, FetchError[]>> {
+  const result: Result<TopAccountEvent[], FetchError[]> =
     await postQueryToAnalyticsApi<AccountBalancesQueryType>(
       top10AccountsQuery(currency),
       'accounts_balances'
     )
-  if ('data' in result) {
-    return { data: { topAccounts: result.data } }
-  } else {
-    return result
-  }
+  return result.ok ? Ok({ topAccounts: result.val }) : result
 }
 
 export default function Top10AccountsCard() {

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.test.tsx
@@ -10,6 +10,7 @@ import Top10TransactionsCard, {
 } from './Top10TransactionsCard'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
+import { Ok } from 'ts-results'
 
 jest.useFakeTimers().setSystemTime(new Date('2021-01-01').getTime())
 
@@ -19,9 +20,7 @@ jest.mock('../../../api_clients/AnalyticsClient', () => ({
 
 const renderSubject = async (transactions: TopSentPaymentEvent[] = []) => {
   // @ts-ignore TS is bad at mocking
-  postQueryToAnalyticsApi.mockResolvedValue({
-    data: transactions,
-  })
+  postQueryToAnalyticsApi.mockResolvedValue(Ok(transactions))
 
   render(
     <BrowserRouter>

--- a/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
+++ b/src/Pages/LeaderboardPage/Cards/Top10TransactionsCard.tsx
@@ -2,7 +2,7 @@ import ApiRequestComponent, {
   ErrorCardComponent,
   LoadingCardComponent,
 } from '../../../ApiRequestComponent'
-import { DataOrErrors } from '../../../api_clients/FetchTypes'
+import { FetchError } from '../../../api_clients/FetchTypes'
 import { postQueryToAnalyticsApi } from '../../../api_clients/AnalyticsClient'
 import { top10Transactions } from '../../../api_clients/AnalyticsQueries'
 import { KnownCurrency } from '../../../api_clients/BlockchainRestTypes'
@@ -10,6 +10,7 @@ import { Card } from 'react-bootstrap'
 import Table, { column } from '../../../Table'
 import ReactTooltip from 'react-tooltip'
 import { TransactionVersion } from '../../../TableComponents/Link'
+import { Ok, Result } from 'ts-results'
 
 export interface TopSentPaymentEvent {
   // eslint-disable-next-line camelcase
@@ -65,17 +66,13 @@ function Top10TransactionsTable({
 
 async function getTopTransactions(
   currency: KnownCurrency
-): Promise<DataOrErrors<Top10TransactionsTableProps>> {
-  const result: DataOrErrors<TopSentPaymentEvent[]> =
+): Promise<Result<Top10TransactionsTableProps, FetchError[]>> {
+  const result: Result<TopSentPaymentEvent[], FetchError[]> =
     await postQueryToAnalyticsApi(
       top10Transactions(currency),
       'sentpayment_events'
     )
-  if ('data' in result) {
-    return { data: { topPayments: result.data } }
-  } else {
-    return result
-  }
+  return result.ok ? Ok({ topPayments: result.val }) : result
 }
 
 export default function Top10TransactionsCard() {

--- a/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
+++ b/src/Pages/TxnDetailsPage/TxnDetailsPage.test.tsx
@@ -15,6 +15,7 @@ import {
   BlockchainUserTxnData,
   BlockchainWritesetTxnData,
 } from '../../api_models/BlockchainTransaction'
+import { Ok } from 'ts-results'
 
 jest.mock('../../api_clients/BlockchainRestClient', () => ({
   ...jest.requireActual('../../api_clients/BlockchainRestClient'),
@@ -66,9 +67,8 @@ const renderWithTransaction = async (
   txn: BlockchainTransaction = mockUserTransaction
 ) => {
   // @ts-ignore TS is bad at mocking
-  getBlockchainTransaction.mockResolvedValue({
-    data: txn,
-  })
+  getBlockchainTransaction.mockResolvedValue(Ok(txn))
+
   const mockHistory = {
     history: {} as any,
     location: {} as any,
@@ -81,11 +81,13 @@ const renderWithTransaction = async (
       },
     },
   }
+
   render(
     <BrowserRouter>
       <TxnDetailsPage {...mockHistory} />
     </BrowserRouter>
   )
+
   await waitForElementToBeRemoved(screen.queryByRole('loading'))
 }
 

--- a/src/api_clients/FetchTypes.test.ts
+++ b/src/api_clients/FetchTypes.test.ts
@@ -1,26 +1,21 @@
-import { DataOrErrors, isNotFound } from './FetchTypes'
+import { FetchError, isNotFound } from './FetchTypes'
+import { Err, Ok, Result } from 'ts-results'
+import { ResponseErrorType } from './FetchBroker'
 
 describe('isNotFound', () => {
   it('should return true if given not found error', () => {
-    const subjects = [
-      { errors: [{ message: 'Not found' }] },
-      { errors: [{ message: 'some other problem' }, { message: 'Not found' }] },
-    ]
-
-    for (const subject of subjects) {
-      expect(isNotFound(subject)).toBeTruthy()
-    }
+    expect(
+      isNotFound(Err([{ message: ResponseErrorType.NOT_FOUND }]))
+    ).toBeTruthy()
   })
+
   it('should return false if anything else', () => {
-    const subjects: DataOrErrors<any, any>[] = [
-      { errors: [{ message: 'Too hot' }] },
-      { errors: [{ status: '404' }] },
-      { data: [{ message: 'Not Found' }] },
-      { data: [{ message: 'Found' }] },
+    const subjects: Result<any, FetchError[]>[] = [
+      Err([{ message: ResponseErrorType.UNHANDLED }]),
+      Ok({ message: 'Not Found' }),
+      Ok({ message: 'Too cold' }),
     ]
 
-    for (const subject of subjects) {
-      expect(isNotFound(subject)).toBeFalsy()
-    }
+    for (const subject of subjects) expect(isNotFound(subject)).toBeFalsy()
   })
 })

--- a/src/api_clients/FetchTypes.ts
+++ b/src/api_clients/FetchTypes.ts
@@ -1,4 +1,5 @@
-import { ResponseError } from './FetchBroker'
+import { ResponseErrorType } from './FetchBroker'
+import { Result } from 'ts-results'
 
 export type FetchError = {
   message: string
@@ -6,12 +7,10 @@ export type FetchError = {
   code?: number
 }
 
-export type DataOrErrors<T, R = FetchError[]> = { data: T } | { errors: R }
-
-export function isNotFound<T, R>(dataOrError: DataOrErrors<T, R>): boolean {
-  if (!('errors' in dataOrError)) return false
-  if (!Array.isArray(dataOrError.errors)) return false
-  return dataOrError.errors.some(
-    (error) => error?.message === ResponseError.NOT_FOUND
+export function isNotFound<T>(result: Result<T, FetchError[]>): boolean {
+  if (!('err' in result)) return false
+  else if (!Array.isArray(result.val)) return false
+  return result.val.some(
+    (error) => error?.message === ResponseErrorType.NOT_FOUND
   )
 }


### PR DESCRIPTION
## Motivation:

Replacing `DataOrErrors` will enable developers to utilize a library (`result-ts`) that manages to accomplish everything that `DataOrErrors` strives to achieve without having to maintain extra code (`DataOrErrors`).