### PR TITLE
Remove eslint rules that conflict with prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,9 +39,6 @@
         ],
         "space-before-function-paren": 0,
         "comma-dangle": "off",
-        "indent": ["error", 2, { "SwitchCase": 1 }],
-        "react/jsx-indent": ["error", 2],
-        "react/jsx-indent-props": ["error", 2],
         "dot-notation": "off"
     },
     "settings": {

--- a/src/Pages/AccountPage/AccountPage.tsx
+++ b/src/Pages/AccountPage/AccountPage.tsx
@@ -153,9 +153,9 @@ const getAccountResourceResponse = (
   return diemAccountResource
     ? Ok(diemAccountResource)
     : Err({
-      type: ResponseErrorType.UNHANDLED,
-      message: 'Account resource not found',
-    })
+        type: ResponseErrorType.UNHANDLED,
+        message: 'Account resource not found',
+      })
 }
 
 function isNotFound<T>(

--- a/src/api_clients/AnalyticsClient.ts
+++ b/src/api_clients/AnalyticsClient.ts
@@ -17,10 +17,10 @@ export const postQueryToAnalyticsApi = async <T>(
   } catch (err: any) {
     return 'response' in err && 'errors' in err.response
       ? Err([
-        ...err.response.errors.map(
-          ({ message }: { message: string }) => message
-        ),
-      ])
+          ...err.response.errors.map(
+            ({ message }: { message: string }) => message
+          ),
+        ])
       : Err([{ message: err.message }])
   }
 }


### PR DESCRIPTION
`eslint-config-prettier` provides indentation rules of its own, so the explicit eslint rules for indentation were doing at best nothing, and at worst conflicting with the Prettier settings. The remedy recommended by [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) is to remove these rules.

The conflicting indentation has also been updated to match Prettier's formatting.

Closes #123 